### PR TITLE
Fix for NaNs at infinity + Update/upgrade of perturbations

### DIFF
--- a/UAv_IDBHScalarHair/param.ccl
+++ b/UAv_IDBHScalarHair/param.ccl
@@ -80,24 +80,34 @@ REAL z0 "z coordinate of central point"
 } 0.0
 
 
-REAL Apert_BH "maximum amplitude for BH perturbation"
+REAL Apert_conf_fac "maximum amplitude for conformal factor perturbation"
 {
   0:* :: "non-negative"
 } 0.0
 
-REAL R0pert "center of perturbation"
+REAL R0pert_conf_fac "center radius for conformal factor perturbation. To be conceived in quasi-isotropic coordinate R"
 {
   0:* :: "non-negative"
 } 0.0
+
+REAL Sigmapert_conf_fac "spread for conformal factor perturbation. To be conceived in quasi-isotropic coordinate R"
+{
+  (0:* :: "positive"
+} 1.0
 
 REAL Apert_phi "maximum amplitude for scalar perturbation"
 {
   0:* :: "non-negative"
 } 0.0
 
-REAL Rphi_pert "radius for scalar perturbation"
+REAL R0pert_phi "center radius for scalar perturbation. To be conceived in quasi-isotropic coordinate R"
 {
   0:* :: "non-negative"
+} 0.0
+
+REAL Sigmapert_phi "spread for scalar perturbation. To be conceived in quasi-isotropic coordinate R"
+{
+  (0:* :: "positive"
 } 1.0
 
 

--- a/UAv_IDBHScalarHair/src/BHScalarHair.c
+++ b/UAv_IDBHScalarHair/src/BHScalarHair.c
@@ -504,13 +504,11 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
         const CCTK_REAL dW_dr    = dWbar_dr[ind] / rr2 - 2 * Wbar[ind] / rr3;
         const CCTK_REAL d2W_drth = d2Wbar_drth[ind] / rr2 - 2 * dWbar_dth[ind] / rr3;
 
-        // add non-axisymmetric perturbation
-        const CCTK_REAL RR0pert2 = (RR - R0pert)*(RR - R0pert);
-        // horizon location
-        const CCTK_REAL RH = rH * 0.25;
-        const CCTK_REAL pert = 1. + Apert_BH * (x1*x1 - y1*y1)/(mu*mu) * exp( -0.5*RR0pert2/(RH*RH) );
+        // add non-axisymmetric perturbation on conformal factor
+        const CCTK_REAL argpert_cf = (RR - R0pert_conf_fac)/Sigmapert_conf_fac;
+        const CCTK_REAL pert_cf = 1. + Apert_conf_fac * (x1*x1 - y1*y1)*mu*mu * exp( -0.5*argpert_cf*argpert_cf );
 
-        const CCTK_REAL conf_fac = psi4 * pert;
+        const CCTK_REAL conf_fac = psi4 * pert_cf;
 
         // 3-metric
         gxx[ind] = conf_fac * (1. + h_rho2 * sinph * sinph);
@@ -555,7 +553,8 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
 
 
         // let's add a perturbation to the scalar field as well
-        const CCTK_REAL pert_phi = 1. + Apert_phi * (x1*x1 - y1*y1)/(Rphi_pert*Rphi_pert);
+        const CCTK_REAL argpert_phi = (RR - R0pert_phi)/Sigmapert_phi;
+        const CCTK_REAL pert_phi = 1. + Apert_phi * (x1*x1 - y1*y1)*mu*mu * exp( -0.5*argpert_phi*argpert_phi );
 
         const CCTK_REAL phi0_l = phi0[ind] * pert_phi;
 


### PR DESCRIPTION
1) Fixed the treatment of point X==1, which was giving NaNs through the coordinate change.
2) Rearranged a bit the perturbation parameters and expressions, so that the conformal factor and scalar field perturbations are now similar, with three parameters each (plus small correction on mu units).

**/!\ WARNING (backwards compatibility):** The names of some parameters have been modified! Namely:
    + Changes
        - Apert_BH     --> Apert_conf_fac
        - R0pert          --> R0pert_conf_fac
        - Rphi_pert     --> R0pert_phi
    + Unchanged
        - Apert_phi
    + New
        - Sigmapert_conf_fac
        - Sigmapert_phi