### PR TITLE
Adding matter angular momentum and linear momentum density to the Analysis thorn

### DIFF
--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -22,6 +22,20 @@ CCTK_REAL total_energy type=scalar timelevels=1 tags='checkpoint="no"'
 
 CCTK_REAL dE_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortypealias="Scalar" checkpoint="no"' "energy density gridfunction for volume integration"
 
+CCTK_REAL total_angular_momentum type=scalar timelevels=1 tags='checkpoint="no"'
+{
+  total_angular_momentum_x
+  total_angular_momentum_y
+  total_angular_momentum_z
+} "Komar angular momentum (integral computed with respect to rotation around each axis, centered at the origin)"
+
+CCTK_REAL dJ_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortypealias="D" checkpoint="no"'
+{
+  dJx_gf_volume
+  dJy_gf_volume
+  dJz_gf_volume
+} "angular momentum density J_i gridfunctions for volume integration"
+
 CCTK_REAL quadrupole type=scalar timelevels=1 tags='checkpoint="no"'
 {
   Ixx, Ixy, Ixz

--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -53,7 +53,11 @@ CCTK_REAL quadrupole_gf_volume type=gf timelevels=3 tags='Prolongation="none" te
   dIzz_gf_volume
 } "quadrupole moments I_ij gridfunctions for volume integration"
 
-CCTK_REAL densities type=gf timelevels=3 tags='tensortypealias="Scalar" tensorweight=0 Checkpoint="no"'
+CCTK_REAL density_rho type=gf timelevels=3 tags='tensortypealias="Scalar" tensorweight=0 Checkpoint="no"' "Eulerian energy density"
+
+CCTK_REAL density_p type=gf timelevels=3 tags='tensortypealias="D" tensorweight=0 checkpoint="no"'
 {
-  density_rho
-} "energy-momentum densities"
+  density_px
+  density_py
+  density_pz
+} "Eulerian momentum density"

--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -18,7 +18,7 @@ USES FUNCTION Boundary_SelectGroupForBC
 
 private:
 
-CCTK_REAL total_energy type=scalar timelevels=1 tags='checkpoint="no"'
+CCTK_REAL total_energy type=scalar timelevels=1 tags='checkpoint="no"' "Komar mass (volume integral). See Gourgoulhon's 3+1 Formalism, sections 8.6.1 and 8.6.2 (Eq. 8.63 and 8.70)."
 
 CCTK_REAL dE_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortypealias="Scalar" checkpoint="no"' "energy density gridfunction for volume integration"
 
@@ -27,7 +27,7 @@ CCTK_REAL total_angular_momentum type=scalar timelevels=1 tags='checkpoint="no"'
   total_angular_momentum_x
   total_angular_momentum_y
   total_angular_momentum_z
-} "Komar angular momentum (integral computed with respect to rotation around each axis, centered at the origin)"
+} "Komar angular momentum (volume integral computed with respect to rotation around each axis, centered at the origin). See Gourgoulhon's 3+1 Formalism, section 8.6.3 (Eq. 8.75)."
 
 CCTK_REAL dJ_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortypealias="D" checkpoint="no"'
 {

--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -5,3 +5,11 @@
 BOOLEAN excise_horizon "excise the region inside the AH from the volume integrations?" STEERABLE=ALWAYS
 {
 } "no"
+
+BOOLEAN compute_density_rho "Compute the grid function density_rho" STEERABLE=ALWAYS
+{
+} "no"
+
+BOOLEAN compute_density_p "Compute the grid functions density_p" STEERABLE=ALWAYS
+{
+} "no"

--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -6,6 +6,11 @@ BOOLEAN excise_horizon "excise the region inside the AH from the volume integrat
 {
 } "no"
 
+INT do_analysis_every "Perform the analysis (compute the energy, densities...) every N iterations" STEERABLE=ALWAYS
+{
+    *:*  :: "0 or a negative value means never compute them"
+} 1
+
 BOOLEAN compute_density_rho "Compute the grid function density_rho" STEERABLE=ALWAYS
 {
 } "no"

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -6,7 +6,16 @@ storage: quadrupole_gf_volume[3]
 storage: total_energy[1]
 storage: total_angular_momentum[1]
 storage: quadrupole[1]
-storage: densities[3]
+
+# allocate densities if required
+if (compute_density_rho)
+{
+  storage: density_rho[3]
+}
+if (compute_density_p)
+{
+  storage: density_p[3]
+}
 
 schedule UAv_Analysis_RegisterMask at STARTUP
 {
@@ -33,7 +42,8 @@ schedule UAv_Analysis_gfs in UAv_Analysis_Group
   SYNC: dE_gf_volume
   SYNC: dJ_gf_volume
   SYNC: quadrupole_gf_volume
-  SYNC: densities
+  SYNC: density_rho
+  SYNC: density_p
 } "Calculate grid functions"
 
 
@@ -41,7 +51,8 @@ schedule UAv_Analysis_Boundaries after UAv_Analysis_gfs in UAv_Analysis_Group
 {
   LANG: Fortran
   OPTIONS: LEVEL
-  SYNC: densities
+  SYNC: density_rho
+  SYNC: density_p
 } "Enforce symmetry BCs in Analysis"
 
 schedule GROUP ApplyBCs as UAv_Analysis_ApplyBCs after UAv_Analysis_Boundaries in UAv_Analysis_Group

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -30,7 +30,7 @@ schedule UAv_Analysis_Symmetries at BASEGRID
 } "Register symmetries of the density functions"
 
 
-schedule GROUP UAv_Analysis_Group at CCTK_POSTSTEP after AHFinderDirect_maybe_do_masks
+schedule GROUP UAv_Analysis_Group at ANALYSIS
 {
 } "Compute several diagnostic quantities"
 
@@ -38,7 +38,6 @@ schedule GROUP UAv_Analysis_Group at CCTK_POSTSTEP after AHFinderDirect_maybe_do
 schedule UAv_Analysis_gfs in UAv_Analysis_Group
 {
   LANG: Fortran
-  OPTIONS: global loop-local
   SYNC: dE_gf_volume
   SYNC: dJ_gf_volume
   SYNC: quadrupole_gf_volume
@@ -60,7 +59,7 @@ schedule GROUP ApplyBCs as UAv_Analysis_ApplyBCs after UAv_Analysis_Boundaries i
 } "Apply boundary conditions"
 
 
-schedule UAv_Analysis_IntegrateVol at CCTK_ANALYSIS
+schedule UAv_Analysis_IntegrateVol after UAv_Analysis_ApplyBCs in UAv_Analysis_Group
 {
   LANG: Fortran
   OPTIONS: global

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -29,8 +29,17 @@ schedule UAv_Analysis_Symmetries at BASEGRID
   OPTIONS: Global
 } "Register symmetries of the density functions"
 
+###############################################################################
+# WARNING/NOTE: It seemed it was needed to change the UAv_Analysis_gfs OPTIONS
+# from "global loop-local" to the default "local", for the "do_analysis_every"
+# feature to work properly (specifically, for the output of the density GFs.
+# The integrals total_energy/ang. mom were fine). 
+# It seems to be working fine with AHFinderDirect, even when the latter runs
+# at ANALYSIS, but if in doubt, maybe run AHFinderDirect at POSTSTEP (which
+# is the current default), this should make sure the excision mask is there.
+###############################################################################
 
-schedule GROUP UAv_Analysis_Group at ANALYSIS
+schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_masks
 {
 } "Compute several diagnostic quantities"
 

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -1,8 +1,10 @@
 # Schedule definitions for thorn UAv_Analysis
 
 storage: dE_gf_volume[3]
+storage: dJ_gf_volume[3]
 storage: quadrupole_gf_volume[3]
 storage: total_energy[1]
+storage: total_angular_momentum[1]
 storage: quadrupole[1]
 storage: densities[3]
 
@@ -29,6 +31,7 @@ schedule UAv_Analysis_gfs in UAv_Analysis_Group
   LANG: Fortran
   OPTIONS: global loop-local
   SYNC: dE_gf_volume
+  SYNC: dJ_gf_volume
   SYNC: quadrupole_gf_volume
   SYNC: densities
 } "Calculate grid functions"

--- a/UAv_Analysis/src/UAv_Analysis.F90
+++ b/UAv_Analysis/src/UAv_Analysis.F90
@@ -28,7 +28,14 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
   type_bits     = -1
   state_outside = -1
-
+  
+  if (do_analysis_every .le. 0) then
+     return
+  end if
+  
+  if (MOD(cctk_iteration, do_analysis_every) .ne. 0 ) then
+     return
+  endif
 
   if (excise_horizon /= 0) then
 
@@ -224,6 +231,14 @@ subroutine UAv_Analysis_IntegrateVol( CCTK_ARGUMENTS )
   CCTK_REAL Jx_int, Jy_int, Jz_int
   CCTK_REAL Ixx_int, Ixy_int, Ixz_int, Iyy_int, Iyz_int, Izz_int
 
+  if (do_analysis_every .le. 0) then
+     return
+  end if
+
+  if (MOD(cctk_iteration, do_analysis_every) .ne. 0 ) then
+     return
+  endif
+  
   call CCTK_ReductionHandle(reduction_handle, 'sum')
   if (reduction_handle < 0) then
      call CCTK_WARN(0, 'Could not obtain a handle for sum reduction')

--- a/UAv_Analysis/src/UAv_Analysis.F90
+++ b/UAv_Analysis/src/UAv_Analysis.F90
@@ -56,7 +56,14 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
   dIyy_gf_volume = 0
   dIyz_gf_volume = 0
   dIzz_gf_volume = 0
-  density_rho    = 0
+  if (compute_density_rho == 1) then
+     density_rho    = 0
+  end if
+  if (compute_density_p == 1) then
+     density_px     = 0
+     density_py     = 0
+     density_pz     = 0
+  end if
 
   do k = 1+cctk_nghostzones(3), cctk_lsh(3)-cctk_nghostzones(3)
   do j = 1+cctk_nghostzones(2), cctk_lsh(2)-cctk_nghostzones(2)
@@ -145,17 +152,25 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
     end do
     rho = rho / ( alph * alph )
 
-    density_rho(i,j,k) = rho
-
+    if (compute_density_rho == 1) then
+      density_rho(i,j,k) = rho
+    end if
+    
     ! momentum density
     do n = 1, 3
-    mom(n) = Tab(4,n)
+      mom(n) = Tab(4,n)
       do m = 1, 3
-        mom(n) = mom(n) - beta(m) * Tab(m,n)
+         mom(n) = mom(n) - beta(m) * Tab(m,n)
       end do
       mom(n) = - mom(n) / alph
     end do
-
+   
+    if (compute_density_p == 1) then
+      density_px(i,j,k) = mom(1)
+      density_py(i,j,k) = mom(2)
+      density_pz(i,j,k) = mom(3)
+    end if
+   
 
     aux = 0
     do m = 1, 3

--- a/UAv_Analysis/src/UAv_Boundaries.F90
+++ b/UAv_Analysis/src/UAv_Boundaries.F90
@@ -14,6 +14,14 @@ subroutine UAv_Analysis_Boundaries( CCTK_ARGUMENTS )
   CCTK_INT, parameter :: one = 1
   CCTK_INT, parameter :: bndsize = 3
 
+  if (do_analysis_every .le. 0) then
+     return
+  end if
+
+  if (MOD(cctk_iteration, do_analysis_every) .ne. 0 ) then
+     return
+  endif
+
   if (compute_density_rho == 1) then
      ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, bndsize, -one, &
           "UAv_Analysis::density_rho", "flat")

--- a/UAv_Analysis/src/UAv_Boundaries.F90
+++ b/UAv_Analysis/src/UAv_Boundaries.F90
@@ -14,9 +14,18 @@ subroutine UAv_Analysis_Boundaries( CCTK_ARGUMENTS )
   CCTK_INT, parameter :: one = 1
   CCTK_INT, parameter :: bndsize = 3
 
-  ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, bndsize, -one, &
-       "UAv_Analysis::densities", "flat")
-  if (ierr < 0)                                                           &
-       call CCTK_ERROR("Failed to register BC for UAv_Analysis::densities!")
+  if (compute_density_rho == 1) then
+     ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, bndsize, -one, &
+          "UAv_Analysis::density_rho", "flat")
+     if (ierr < 0)                                                           &
+          call CCTK_ERROR("Failed to register BC for UAv_Analysis::density_rho!")
+  end if
+
+  if (compute_density_p == 1) then 
+     ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, bndsize, -one, &
+          "UAv_Analysis::density_p", "flat")
+     if (ierr < 0)                                                           &
+          call CCTK_ERROR("Failed to register BC for UAv_Analysis::density_p!")
+  end if
 
 end subroutine UAv_Analysis_Boundaries

--- a/UAv_Analysis/src/UAv_Symmetries.F90
+++ b/UAv_Analysis/src/UAv_Symmetries.F90
@@ -13,5 +13,8 @@ subroutine UAv_Analysis_Symmetries( CCTK_ARGUMENTS )
   CCTK_INT ierr
 
   call SetCartSymVN( ierr, cctkGH, (/ 1, 1, 1/), "UAv_Analysis::density_rho" )
+  call SetCartSymVN( ierr, cctkGH, (/-1, 1, 1/), "UAv_Analysis::density_px" )
+  call SetCartSymVN( ierr, cctkGH, (/ 1,-1, 1/), "UAv_Analysis::density_py" )
+  call SetCartSymVN( ierr, cctkGH, (/ 1, 1,-1/), "UAv_Analysis::density_pz" )
 
 end subroutine UAv_Analysis_Symmetries

--- a/UAv_IDBHScalarHair/schedule.ccl
+++ b/UAv_IDBHScalarHair/schedule.ccl
@@ -33,4 +33,5 @@ if (CCTK_Equals(initial_data, "ScalarBS"))
 schedule UAv_IDBHScalarHair_ParamCheck AT ParamCheck
 {
   LANG: C
+  OPTIONS: global
 } "Check UAv_IDBHScalarHair parameters for consistency"


### PR DESCRIPTION
The main point of this batch of modifications was to compute the matter total angular momentum (Komar integral), as was done previously with the total energy. Some related concurrent modifications and additions have been implemented.
- Addition of _total_angular_momentum_z_ (likewise for x, y) and related auxiliary grid functions. Complement to the descriptive comments in the _interface.ccl_ file.
- Addition of the linear momentum density, with the group _density_p_, as a possible output; renaming of the group _densities_ into _density_rho_ which it solely contained. Addition of the respective parameters which control whether these grid functions are computed (and allocated) or not. This does not affect the computation of the Komar integrals.
**/!\ The default is not to compute them, beware older parameter files.** This should only issue a warning by Cactus, saying that for instance _density_rho_ doesn't have storage.
- Addition of a _do_analysis_every_ parameter. The introduction of this feature required a change of schedule options (_global loop-local_ to default _local_), which has been made explicit as a comment in the _schedule.ccl_ file.
- Moved all the analysis functions to the _ANALYSIS_ bin. This cures the apparition of NaNs after restarting from checkpoint.
______________
- **Other** (UAv_IDBHScalarHair): Changed schedule option of the _ParamCheck_ function to _global_.
 