### PR TITLE
UAv_Analysis: use a different origin for the analysis (angular momentum, quadrupole)

### DIFF
--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -61,3 +61,15 @@ CCTK_REAL density_p type=gf timelevels=3 tags='tensortypealias="D" tensorweight=
   density_py
   density_pz
 } "Eulerian momentum density"
+
+CCTK_REAL origin_coordinates type=scalar tags='checkpoint="no"'
+{
+  x0, y0, z0
+} "Coordinates of the origin used in the analysis"
+
+CCTK_INT origin_from_grid_scalar_index type=scalar tags='checkpoint="no"' 
+{
+  origin_from_grid_scalar_index_x
+  origin_from_grid_scalar_index_y
+  origin_from_grid_scalar_index_z
+} "Auxiliary to store the Cactus indices of the grid scalars tracking the origin"

--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -18,3 +18,40 @@ BOOLEAN compute_density_rho "Compute the grid function density_rho" STEERABLE=AL
 BOOLEAN compute_density_p "Compute the grid functions density_p" STEERABLE=ALWAYS
 {
 } "no"
+
+BOOLEAN track_origin_from_grid_scalar "Track analysis origin from given grid scalar (used for angular momentum, quadrupole). If not, fixed coordinates are used for the origin." STEERABLE=RECOVER
+{
+} "no"
+
+STRING track_origin_source_x "grid scalar containing the x component of the origin estimate" STEERABLE=RECOVER
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+STRING track_origin_source_y "grid scalar containing the y component of the origin estimate" STEERABLE=RECOVER
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+STRING track_origin_source_z "grid scalar containing the z component of the origin estimate" STEERABLE=RECOVER
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+REAL origin_x "x coordinate for the fixed origin used in the analysis" STEERABLE=RECOVER
+{
+    *:*     :: "Any real number"
+} 0.0
+
+REAL origin_y "y coordinate for the fixed origin used in the analysis" STEERABLE=RECOVER
+{
+    *:*     :: "Any real number"
+} 0.0
+
+REAL origin_z "z coordinate for the fixed origin used in the analysis" STEERABLE=RECOVER
+{
+    *:*     :: "Any real number"
+} 0.0

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -17,17 +17,36 @@ if (compute_density_p)
   storage: density_p[3]
 }
 
+storage: origin_coordinates
+
+# allocate auxiliary index of tracked grid scalars
+if (track_origin_from_grid_scalar) {
+  storage: origin_from_grid_scalar_index
+}
+
+
 schedule UAv_Analysis_RegisterMask at STARTUP
 {
   LANG: C
 } "Register the masks for excision"
 
+schedule UAv_Analysis_ParamCheck AT ParamCheck
+{
+  LANG: C
+  OPTIONS: global
+} "Check UAv_Analysis parameters for consistency"
 
 schedule UAv_Analysis_Symmetries at BASEGRID
 {
   LANG: Fortran
   OPTIONS: Global
 } "Register symmetries of the density functions"
+
+schedule UAv_Initialization at BASEGRID
+{
+  LANG: C
+  OPTIONS: global
+} "Initialize quantities used in the analysis"
 
 ###############################################################################
 # WARNING/NOTE: It seemed it was needed to change the UAv_Analysis_gfs OPTIONS
@@ -43,8 +62,19 @@ schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_mask
 {
 } "Compute several diagnostic quantities"
 
+# Track origin at global-early time (i.e. like coarsest level),
+# to be done before UAv_Analysis_gfs (which is local)
 
-schedule UAv_Analysis_gfs in UAv_Analysis_Group
+if (track_origin_from_grid_scalar)
+{
+  schedule UAv_Track_origin in UAv_Analysis_Group
+  {
+    LANG: C
+    OPTIONS: global-early
+  } "Track the coordinates of the origin used in the analysis"
+}
+
+schedule UAv_Analysis_gfs in UAv_Analysis_Group after UAv_Track_origin
 {
   LANG: Fortran
   SYNC: dE_gf_volume

--- a/UAv_Analysis/src/ParamCheck.c
+++ b/UAv_Analysis/src/ParamCheck.c
@@ -1,0 +1,42 @@
+/* ParamCheck.c : Check that the parameters provided make sense                  */
+/* ============================================================================= */
+
+#include "cctk.h"
+#include "cctk_Arguments.h"
+#include "cctk_Parameters.h"
+
+void UAv_Analysis_ParamCheck(CCTK_ARGUMENTS){
+
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  // Check validity of grid scalars provided
+  if (track_origin_from_grid_scalar) {
+    CCTK_INT index;
+    // x
+    index = CCTK_VarIndex (track_origin_source_x);
+    if (index < 0) {
+      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_x: %s.", track_origin_source_x);
+    }
+    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+      CCTK_VPARAMWARN("Chosen track_origin_source_x: %s is not a grid scalar.", track_origin_source_x);
+    }
+    // y
+    index = CCTK_VarIndex (track_origin_source_y);
+    if (index < 0) {
+      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_y: %s.", track_origin_source_y);
+    }
+    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+      CCTK_VPARAMWARN("Chosen track_origin_source_y: %s is not a grid scalar.", track_origin_source_y);
+    }
+    // z
+    index = CCTK_VarIndex (track_origin_source_z);
+    if (index < 0) {
+      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_z: %s.", track_origin_source_z);
+    }
+    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+      CCTK_VPARAMWARN("Chosen track_origin_source_z: %s is not a grid scalar.", track_origin_source_z);
+    }
+  }
+
+}

--- a/UAv_Analysis/src/UAv_Analysis.F90
+++ b/UAv_Analysis/src/UAv_Analysis.F90
@@ -14,21 +14,14 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
   CCTK_REAL alph, beta(3), Tab(4,4)
   CCTK_REAL gd(3,3), gu(3,3), detgd
-  
+
   CCTK_REAL aux, S, rho
   CCTK_REAL mom(3)
   
-  CCTK_REAL x0, y0, z0, x1, y1, z1, xtmp, ytmp, ztmp
-  CCTK_INT gs_index_tmp_x, gs_index_tmp_y, gs_index_tmp_z
-  
-  CCTK_POINTER ori_ptr_x, ori_ptr_y, ori_ptr_z
-  pointer (ori_ptr_x, xtmp)
-  pointer (ori_ptr_y, ytmp)
-  pointer (ori_ptr_z, ztmp)
+  ! names x0, y0, z0 used as members of the thorn
+  ! They are set in dedicated functions, to be called before this routine
+  CCTK_REAL x1, y1, z1
 
-  character*200 grid_scalar
-  CCTK_INT grid_scalar_len
-  
   CCTK_INT  i, j, k, m, n
 
   CCTK_INT type_bits, state_outside
@@ -61,39 +54,7 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
   end if
 
-  ! Coordinates of the origin used in angular momentum, quadrupole
-  if (track_origin_from_grid_scalar /= 0) then
-      ! Get the index of variables. This is to check if they change.
-      ! If they change, there's no point in using them, just use CCTK_VarDataPtr with the name directly
-      ! If they don't change, we can store them at initialization and don't bother with CCTK_STRING in Fortran
-      write(*,*) 'Getting variable indices in UAv_Analysis'
-      ! x
-      call CCTK_FortranString(grid_scalar_len, track_origin_source_x, grid_scalar)
-      call CCTK_VarIndex(gs_index_tmp_x, grid_scalar(1:grid_scalar_len))
-      write(*,*) 'Index of x source: ', gs_index_tmp_x
-      ! y
-      call CCTK_FortranString(grid_scalar_len, track_origin_source_y, grid_scalar)
-      call CCTK_VarIndex(gs_index_tmp_y, grid_scalar(1:grid_scalar_len))
-      write(*,*) 'Index of y source: ', gs_index_tmp_y
-      ! z
-      call CCTK_FortranString(grid_scalar_len, track_origin_source_z, grid_scalar)
-      call CCTK_VarIndex(gs_index_tmp_z, grid_scalar(1:grid_scalar_len))
-      write(*,*) 'Index of z source: ', gs_index_tmp_z
-
-      call CCTK_VarDataPtrI(ori_ptr_x, cctkGH, 0, gs_index_tmp_x)
-      call CCTK_VarDataPtrI(ori_ptr_y, cctkGH, 0, gs_index_tmp_y)
-      call CCTK_VarDataPtrI(ori_ptr_z, cctkGH, 0, gs_index_tmp_z)
-      
-      x0 = xtmp
-      y0 = ytmp
-      z0 = ztmp
-  else
-      x0 = origin_x
-      y0 = origin_y
-      z0 = origin_z
-  end if
-
-!   write(*,*) 'Tracking origin in UAv_Analysis'
+!   write(*,*) 'Checking origin coordinates for the analysis in UAv_Analysis'
 !   write(*,*) 'x0 = ', x0
 !   write(*,*) 'y0 = ', y0
 !   write(*,*) 'z0 = ', z0
@@ -282,7 +243,7 @@ subroutine UAv_Analysis_IntegrateVol( CCTK_ARGUMENTS )
 
   if (MOD(cctk_iteration, do_analysis_every) .ne. 0 ) then
      return
-  endif
+  end if
   
   call CCTK_ReductionHandle(reduction_handle, 'sum')
   if (reduction_handle < 0) then

--- a/UAv_Analysis/src/UAv_Analysis.F90
+++ b/UAv_Analysis/src/UAv_Analysis.F90
@@ -14,12 +14,21 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
   CCTK_REAL alph, beta(3), Tab(4,4)
   CCTK_REAL gd(3,3), gu(3,3), detgd
-
+  
   CCTK_REAL aux, S, rho
   CCTK_REAL mom(3)
+  
+  CCTK_REAL x0, y0, z0, x1, y1, z1, xtmp, ytmp, ztmp
+  CCTK_INT gs_index_tmp_x, gs_index_tmp_y, gs_index_tmp_z
+  
+  CCTK_POINTER ori_ptr_x, ori_ptr_y, ori_ptr_z
+  pointer (ori_ptr_x, xtmp)
+  pointer (ori_ptr_y, ytmp)
+  pointer (ori_ptr_z, ztmp)
 
-  CCTK_REAL x1, y1, z1
-
+  character*200 grid_scalar
+  CCTK_INT grid_scalar_len
+  
   CCTK_INT  i, j, k, m, n
 
   CCTK_INT type_bits, state_outside
@@ -52,6 +61,42 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
   end if
 
+  ! Coordinates of the origin used in angular momentum, quadrupole
+  if (track_origin_from_grid_scalar /= 0) then
+      ! Get the index of variables. This is to check if they change.
+      ! If they change, there's no point in using them, just use CCTK_VarDataPtr with the name directly
+      ! If they don't change, we can store them at initialization and don't bother with CCTK_STRING in Fortran
+      write(*,*) 'Getting variable indices in UAv_Analysis'
+      ! x
+      call CCTK_FortranString(grid_scalar_len, track_origin_source_x, grid_scalar)
+      call CCTK_VarIndex(gs_index_tmp_x, grid_scalar(1:grid_scalar_len))
+      write(*,*) 'Index of x source: ', gs_index_tmp_x
+      ! y
+      call CCTK_FortranString(grid_scalar_len, track_origin_source_y, grid_scalar)
+      call CCTK_VarIndex(gs_index_tmp_y, grid_scalar(1:grid_scalar_len))
+      write(*,*) 'Index of y source: ', gs_index_tmp_y
+      ! z
+      call CCTK_FortranString(grid_scalar_len, track_origin_source_z, grid_scalar)
+      call CCTK_VarIndex(gs_index_tmp_z, grid_scalar(1:grid_scalar_len))
+      write(*,*) 'Index of z source: ', gs_index_tmp_z
+
+      call CCTK_VarDataPtrI(ori_ptr_x, cctkGH, 0, gs_index_tmp_x)
+      call CCTK_VarDataPtrI(ori_ptr_y, cctkGH, 0, gs_index_tmp_y)
+      call CCTK_VarDataPtrI(ori_ptr_z, cctkGH, 0, gs_index_tmp_z)
+      
+      x0 = xtmp
+      y0 = ytmp
+      z0 = ztmp
+  else
+      x0 = origin_x
+      y0 = origin_y
+      z0 = origin_z
+  end if
+
+!   write(*,*) 'Tracking origin in UAv_Analysis'
+!   write(*,*) 'x0 = ', x0
+!   write(*,*) 'y0 = ', y0
+!   write(*,*) 'z0 = ', z0
 
   dE_gf_volume   = 0
   dJx_gf_volume  = 0
@@ -105,9 +150,9 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
     beta(2) = betay(i,j,k)
     beta(3) = betaz(i,j,k)
 
-    x1      = x(i,j,k)
-    y1      = y(i,j,k)
-    z1      = z(i,j,k)
+    x1      = x(i,j,k) - x0
+    y1      = y(i,j,k) - y0
+    z1      = z(i,j,k) - z0
 
     ! stress-energy tensor variables
     Tab = 0
@@ -199,7 +244,7 @@ subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
 
     dE_gf_volume(i,j,k)   = (alph * S + aux) * sqrt(detgd)
 
-    ! dJz = (-y p_x + x p_y) sqrt(detgd)        + rotations
+    ! dJz = (-y p_x + x p_y) sqrt(detgd)        + permutations
     dJz_gf_volume(i,j,k)  = (-y1 * mom(1) + x1 * mom(2)) * sqrt(detgd)
     dJx_gf_volume(i,j,k)  = (-z1 * mom(2) + y1 * mom(3)) * sqrt(detgd)
     dJy_gf_volume(i,j,k)  = (-x1 * mom(3) + z1 * mom(1)) * sqrt(detgd)

--- a/UAv_Analysis/src/UAv_Analysis.F90
+++ b/UAv_Analysis/src/UAv_Analysis.F90
@@ -291,7 +291,7 @@ subroutine UAv_Analysis_IntegrateVol( CCTK_ARGUMENTS )
 
   ! the multiplication with the volume element needs to be done here
   dV = cctk_delta_space(1) * cctk_delta_space(2) * cctk_delta_space(3)
-  do i = 1,num_out_vals
+  do i = 1,num_in_fields
       out_vals(i) = out_vals(i) * dV
   end do
 

--- a/UAv_Analysis/src/UAv_Initialization.c
+++ b/UAv_Analysis/src/UAv_Initialization.c
@@ -1,0 +1,40 @@
+#include "cctk.h"
+#include "cctk_Arguments.h"
+#include "cctk_Parameters.h"
+
+// Initialize auxiliary members
+void UAv_Initialization (CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  if (track_origin_from_grid_scalar) {
+    // Get the index of variables. It's not supposed to change during the simulation (I think).
+    // Validity of parameters should have been checked in ParamCheck.
+    // Seems a bit redundant to do this affectation here and not in ParamCheck, but more in the logic.
+    
+    // x source
+    *origin_from_grid_scalar_index_x = CCTK_VarIndex (track_origin_source_x);
+    // y source
+    *origin_from_grid_scalar_index_y = CCTK_VarIndex (track_origin_source_y);
+    // z source
+    *origin_from_grid_scalar_index_z = CCTK_VarIndex (track_origin_source_z);
+
+    CCTK_VINFO("Tracking origin used in the analysis with grid scalars.");
+    CCTK_VINFO("x0 = %s", track_origin_source_x);
+    CCTK_VINFO("y0 = %s", track_origin_source_y);
+    CCTK_VINFO("z0 = %s", track_origin_source_z);
+  }
+  else { // no tracking from grid scalar
+    // origin_from_grid_scalar_index not allocated in schedule.ccl in that case
+
+    // We can already initialize the coordinates
+    *x0 = origin_x;
+    *y0 = origin_y;
+    *z0 = origin_z;
+
+    CCTK_VINFO("Using fixed origin in the analysis.");
+    CCTK_VINFO("x0 = %g", *x0);
+    CCTK_VINFO("y0 = %g", *y0);
+    CCTK_VINFO("z0 = %g", *z0);
+  }
+}

--- a/UAv_Analysis/src/UAv_Track_origin.c
+++ b/UAv_Analysis/src/UAv_Track_origin.c
@@ -1,0 +1,35 @@
+#include "cctk.h"
+#include "cctk_Arguments.h"
+#include "cctk_Parameters.h"
+
+
+/*
+  NOTES:
+  - If we want to go more general than fixed coordinates or tracking from a grid scalar,
+  maybe we could have a UAv_Set_origin() function, that would call or incorporate this one.
+  - It could be tempting to just set the x0, y0, z0 pointers to the corresponding variables,
+  at Initialization [though we would need to be really sure that the pointers don't change
+  during a simulation, in any case]. However, these are const pointers, so actually they're
+  read-only, we can't set them. This function takes a negligible time anyway.
+*/
+
+// if (track_origin_from_grid_scalar) in schedule 
+void UAv_Track_origin (CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  if (do_analysis_every < 0) return;
+  if (cctk_iteration % do_analysis_every != 0) return;
+
+  // Track the coordinates of the origin from the chosen grid scalars
+  *x0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_x);
+  *y0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_y);
+  *z0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_z);
+
+
+  // // TODO: Could be added to some verbose parameter...
+  // CCTK_VINFO ("Tracking origin in UAv_Analysis:");
+  // CCTK_VINFO ("x0 = %g", *x0);
+  // CCTK_VINFO ("y0 = %g", *y0);
+  // CCTK_VINFO ("z0 = %g", *z0);
+}

--- a/UAv_Analysis/src/make.code.defn
+++ b/UAv_Analysis/src/make.code.defn
@@ -4,7 +4,10 @@
 SRCS = UAv_AH_mask.c      \
        UAv_Analysis.F90   \
        UAv_Boundaries.F90 \
-       UAv_Symmetries.F90
+       UAv_Symmetries.F90 \
+       UAv_Track_origin.c \
+       UAv_Initialization.c \
+       ParamCheck.c
 
 # Subdirectories containing source files
 SUBDIRS =


### PR DESCRIPTION
Adds the possibility to shift the origin of coordinates used in the analysis when computing the angular momentum and the quadrupole, like in $\int \sqrt{\gamma} [-(y-y_0)p_x + (x-x_0)p_y]$.

This origin can have fixed coordinates -- for consistency, and sensibility, this is the default behavior, with coordinates defaulting to 0.
It can also track a grid scalar (based on _AHFinderDirect_) -- the typical case would be to track a puncture with _pt_loc_x[0]_ ...