### PR TITLE
Small correction (missing C0 factor) in change of coordinate at X==0.

### DIFF
--- a/UAv_IDBHScalarHair/src/BHScalarHair.c
+++ b/UAv_IDBHScalarHair/src/BHScalarHair.c
@@ -236,7 +236,8 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
 
         CCTK_REAL drxdr;
         if (i == 0) { // rx == 0 (X == 0)
-          drxdr = sqrt(rH*rH + rx*rx);
+          // Including here additional C0 contribution from L´Hôpital's rule: d(dr/dx)/dX = dx/dX * d2r/dx2 = C0 / rH at i==0
+          drxdr = rH / C0;
         } else {
           drxdr = sqrt(rH*rH + rx*rx)/rx;
         }


### PR DESCRIPTION
At $X=0$, we use L'Hôpital's rule for $X$ derivative, because $\frac{dx}{dr}$ diverges.
But the derivative of the denomiator, $\frac{dr}{dx}$, was formerly computed with respect to $x$, and not $X$, resulting in a missing $\dfrac{dx}{dX} (X=0) = C_0$ factor.