### PR TITLE
Analysis: fixed string range for origin tracking.

### DIFF
--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -64,23 +64,29 @@ BOOLEAN track_origin_from_grid_scalar "Track analysis origin from given grid sca
 {
 } "no"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING track_origin_source_x "grid scalar containing the x component of the origin estimate" STEERABLE=RECOVER
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING track_origin_source_y "grid scalar containing the y component of the origin estimate" STEERABLE=RECOVER
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING track_origin_source_z "grid scalar containing the z component of the origin estimate" STEERABLE=RECOVER
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
 REAL origin_x "x coordinate for the fixed origin used in the analysis" STEERABLE=RECOVER
 {

--- a/UAv_Analysis/src/ParamCheck.c
+++ b/UAv_Analysis/src/ParamCheck.c
@@ -45,29 +45,38 @@ void UAv_Analysis_ParamCheck(CCTK_ARGUMENTS){
   // Check validity of grid scalars provided
   if (track_origin_from_grid_scalar) {
     CCTK_INT index;
+
     // x
     index = CCTK_VarIndex (track_origin_source_x);
-    if (index < 0) {
-      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_x: %s.", track_origin_source_x);
+    if (!CCTK_Equals(track_origin_source_x, "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_x: %s.", track_origin_source_x);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Chosen track_origin_source_x: %s is not a grid scalar.", track_origin_source_x);
+      }
     }
-    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-      CCTK_VPARAMWARN("Chosen track_origin_source_x: %s is not a grid scalar.", track_origin_source_x);
-    }
+    
     // y
     index = CCTK_VarIndex (track_origin_source_y);
-    if (index < 0) {
-      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_y: %s.", track_origin_source_y);
+    if (!CCTK_Equals(track_origin_source_y, "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_y: %s.", track_origin_source_y);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Chosen track_origin_source_y: %s is not a grid scalar.", track_origin_source_y);
+      }
     }
-    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-      CCTK_VPARAMWARN("Chosen track_origin_source_y: %s is not a grid scalar.", track_origin_source_y);
-    }
+    
     // z
     index = CCTK_VarIndex (track_origin_source_z);
-    if (index < 0) {
-      CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_z: %s.", track_origin_source_z);
-    }
-    if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-      CCTK_VPARAMWARN("Chosen track_origin_source_z: %s is not a grid scalar.", track_origin_source_z);
+    if (!CCTK_Equals(track_origin_source_z, "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of chosen track_origin_source_z: %s.", track_origin_source_z);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Chosen track_origin_source_z: %s is not a grid scalar.", track_origin_source_z);
+      }
     }
   }
 

--- a/UAv_Analysis/src/UAv_Initialization.c
+++ b/UAv_Analysis/src/UAv_Initialization.c
@@ -55,35 +55,47 @@ void UAv_Initialization (CCTK_ARGUMENTS) {
   // ORIGIN TRACKING
   // -------------------------------
 
+  // We can already initialize the coordinates
+  *x0 = origin_x;
+  *y0 = origin_y;
+  *z0 = origin_z;
+
   // Initialize origin tracking if needed
+  // origin_from_grid_scalar_index not allocated in schedule.ccl if track_origin_from_grid_scalar = no
   if (track_origin_from_grid_scalar) {
     // Get the index of variables. It's not supposed to change during the simulation (I think).
     // Validity of parameters should have been checked in ParamCheck.
-    // Seems a bit redundant to do this affectation here and not in ParamCheck, but more in the logic.
-    
+    // Since validity has been checked, a negative value here should mean "fixed".
+
     // x source
     *origin_from_grid_scalar_index_x = CCTK_VarIndex (track_origin_source_x);
     // y source
     *origin_from_grid_scalar_index_y = CCTK_VarIndex (track_origin_source_y);
     // z source
     *origin_from_grid_scalar_index_z = CCTK_VarIndex (track_origin_source_z);
-
-    CCTK_VINFO("Tracking origin used in the analysis with grid scalars.");
-    CCTK_VINFO("x0 = %s", track_origin_source_x);
-    CCTK_VINFO("y0 = %s", track_origin_source_y);
-    CCTK_VINFO("z0 = %s", track_origin_source_z);
   }
-  else { // no tracking from grid scalar
-    // origin_from_grid_scalar_index not allocated in schedule.ccl in that case
-
-    // We can already initialize the coordinates
-    *x0 = origin_x;
-    *y0 = origin_y;
-    *z0 = origin_z;
-
-    CCTK_VINFO("Using fixed origin in the analysis.");
-    CCTK_VINFO("x0 = %g", *x0);
-    CCTK_VINFO("y0 = %g", *y0);
-    CCTK_VINFO("z0 = %g", *z0);
+  
+  // Info
+  CCTK_VINFO("Origin used in the analysis:");
+  // x
+  if (track_origin_from_grid_scalar && *origin_from_grid_scalar_index_x >= 0) {
+    CCTK_VINFO("x0: %s", track_origin_source_x);
+  }
+  else {
+    CCTK_VINFO("x0 = %g (fixed)", *x0);
+  }
+  // y
+  if (track_origin_from_grid_scalar && *origin_from_grid_scalar_index_y >= 0) {
+    CCTK_VINFO("y0: %s", track_origin_source_y);
+  }
+  else {
+    CCTK_VINFO("y0 = %g (fixed)", *y0);
+  }
+  // z
+  if (track_origin_from_grid_scalar && *origin_from_grid_scalar_index_z >= 0) {
+    CCTK_VINFO("z0: %s", track_origin_source_z);
+  }
+  else {
+    CCTK_VINFO("z0 = %g (fixed)", *z0);
   }
 }

--- a/UAv_Analysis/src/UAv_Track_origin.c
+++ b/UAv_Analysis/src/UAv_Track_origin.c
@@ -22,10 +22,16 @@ void UAv_Track_origin (CCTK_ARGUMENTS) {
   if (cctk_iteration % do_analysis_every != 0) return;
 
   // Track the coordinates of the origin from the chosen grid scalars
-  *x0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_x);
-  *y0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_y);
-  *z0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_z);
-
+  // Negative index means "fixed"
+  if (*origin_from_grid_scalar_index_x >= 0) {
+    *x0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_x);
+  }
+  if (*origin_from_grid_scalar_index_y >= 0) {
+    *y0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_y);
+  }
+  if (*origin_from_grid_scalar_index_z >= 0) {
+    *z0 = * (CCTK_REAL*) CCTK_VarDataPtrI(cctkGH, 0, *origin_from_grid_scalar_index_z);
+  }
 
   // // TODO: Could be added to some verbose parameter...
   // CCTK_VINFO ("Tracking origin in UAv_Analysis:");


### PR DESCRIPTION
The range for the name of grid scalars to track `track_origin_source_x/y/z` was taken from AHFinderDirect.
It turns out that the empty string `""` matches everything, so the range was pointless.
What's more, the range regex was not actually matching names of grid scalars.

This PR introduces a `"fixed"` default option instead, which falls back to the coordinate given in `UAv_Analysis::origin_x/y/z`.
It also consistently adds the possibility to choose one or more fixed coordinates in the tracking mode.