### PR TITLE
Analysis: Remove WARNING comments about multipatch behavior.

### DIFF
--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -18,7 +18,6 @@ USES FUNCTION Boundary_SelectGroupForBC
 
 private:
 
-# For information about multipatch/Llama behavior, see WARNING in param.ccl
 # Two separate flags, in case later we implement something with derivatives that use the jacobian, for example
 CCTK_INT is_multipatch type=scalar timelevels=1 tags='checkpoint="no"' "Flag to know if the simulation uses a multipatch grid."
 

--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -1,46 +1,5 @@
 # Parameter definitions for thorn UAv_Analysis
 
-#####################
-###### WARNING ######
-#####################
-# 
-### CONTEXT ###
-# 
-# For multipatch simulations, the computation of volume integrals requires the volume form from thorn Coordinates.
-# So far, we don't include an explicit parameter here for multipatch, 
-# with the philosophy (like evolution thorns) that the simulation should figure it out by itself.
-# 
-### PROBLEM ###
-# 
-# However, at the time of this commit, different patch systems compute the volume form inconsistently.
-# More precisely, Thornburg04 (which is the typical case of interest) sets it so that it can be used directly in the integral
-# (i.e, in the spherical grid, volume_form = h(1)*h(2)*h(3)/abs(detJ)).
-# On the other hand, the default behavior, used for instance by Thornburg04nc, sets volume_form = detJ.
-# This would imply a differentiated treatment in the Analysis which is not desirable.
-# Building blocks of required modifications can be found in legacy commit:
-# 47e14e81b506b918bf6a203fbaa043c3d76339bb
-# 
-### DECISION ###
-# 
-# It is hoped that this will be fixed in Llama directly. To this effect, see the following information:
-# - bug report: https://bitbucket.org/einsteintoolkit/tickets/issues/2912/inconsistent-computation-of-the-volume
-# - mailing list thread: https://lists.einsteintoolkit.org/pipermail/users/2026-January/009856.html
-# 
-# For now, we consider that this should not be tackled here by checking the patch system type.
-# We therefore adopt a single unified treatment, consistent with system Thornburg04,
-# which can use directly the volume form without more information/calculation.
-# THIS WILL GIVE WRONG RESULTS FOR OTHER PATCH SYSTEMS (except Thornburg04 and Thornburg13, latter not tested).
-# 
-### TODO ###
-# 
-# Depending on how this issue evolves, here are possible needed actions:
-# - update/remove this WARNING comment section, and echoes of it in other files
-# - update the code in UAv_Analysis.F90, etc. (for instance if Llama behavior stays unchanged, or changes Thornburg04)
-# - add some comments/warnings/outputs/checks about ET/Llama version and compatibility.
-# 
-#####################
-
-
 # exclude horizon from integration
 
 BOOLEAN excise_horizon "excise the region inside the AH from the volume integrations?" STEERABLE=ALWAYS

--- a/UAv_Analysis/src/ParamCheck.c
+++ b/UAv_Analysis/src/ParamCheck.c
@@ -14,8 +14,6 @@ void UAv_Analysis_ParamCheck(CCTK_ARGUMENTS){
   // MULTIPATCH
   // -------------------------------
   
-  // For information, see WARNING in param.ccl
-
   // For multipatch / Llama grids, we need the volume form computed in Coordinates
   // This is activated by the parameter Coordinates::store_volume_form = yes
 

--- a/UAv_Analysis/src/UAv_Analysis_gfs.F90
+++ b/UAv_Analysis/src/UAv_Analysis_gfs.F90
@@ -6,8 +6,6 @@
 
 #include "SpaceMask.h"
 
-! For information, see WARNING in param.ccl
-
 subroutine UAv_Analysis_gfs( CCTK_ARGUMENTS )
   implicit none
   DECLARE_CCTK_ARGUMENTS

--- a/UAv_Analysis/src/UAv_Initialization.c
+++ b/UAv_Analysis/src/UAv_Initialization.c
@@ -12,8 +12,6 @@ void UAv_Initialization (CCTK_ARGUMENTS) {
   // MULTIPATCH
   // -------------------------------
 
-  // For information, see WARNING in param.ccl
-
   // Setting the flags has to be done here, cannot be done in PARAMCHECK
 
   // Trick to check multipatch usage without having to inherit the thorn


### PR DESCRIPTION
The inconsistent Llama behavior will be fixed in the upcoming ET release. See ET ticket #2912 (https://bitbucket.org/einsteintoolkit/tickets/issues/2912).