### PR TITLE
Tracker thorn

### DIFF
--- a/TargetTracker/interface.ccl
+++ b/TargetTracker/interface.ccl
@@ -1,0 +1,22 @@
+# Interface definition for thorn TargetTracker
+
+implements: TargetTracker
+inherits: SphericalSurface
+
+private:
+
+CCTK_INT is_active[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' "Flag to know which tracker is active"
+
+CCTK_REAL target_loc[nmax_targets] type=scalar timelevels=1
+{
+  target_loc_x
+  target_loc_y
+  target_loc_z
+} "Tracked point coordinates"
+
+CCTK_INT target_ids[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' 
+{
+  target_id_x
+  target_id_y
+  target_id_z
+} "ID of the targets"

--- a/TargetTracker/interface.ccl
+++ b/TargetTracker/interface.ccl
@@ -9,6 +9,8 @@ CCTK_INT is_tracked[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes
 
 CCTK_INT is_active[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' "Flag to know which tracker is active"
 
+CCTK_INT is_loc_from_surface[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' "Flag to know which tracker gets its location from a surface"
+
 CCTK_REAL target_loc[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   target_loc_x

--- a/TargetTracker/interface.ccl
+++ b/TargetTracker/interface.ccl
@@ -5,9 +5,11 @@ inherits: SphericalSurface
 
 private:
 
+CCTK_INT is_tracked[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' "Flag to reflect parameter track (for recovery)"
+
 CCTK_INT is_active[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"' "Flag to know which tracker is active"
 
-CCTK_REAL target_loc[nmax_targets] type=scalar timelevels=1
+CCTK_REAL target_loc[nmax_targets] type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   target_loc_x
   target_loc_y

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -55,7 +55,7 @@ REAL stop_tracking_after_time[10] "Stop tracking after the given time" STEERABLE
   *:* :: "after this time (exclusively)"
 } 1e+99
 
-INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location. Make sure you have created the surface!"
+INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location. Make sure you have created the surface!" STEERABLE=RECOVER
 {
   -1  :: "don't store target location"
   0:* :: "any spherical surface index"

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -19,21 +19,18 @@ BOOLEAN loc_from_surface_mode[10] "Instead of tracking a scalar and set the surf
 {
 } "no"
 
-# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_x[10] "Grid scalar that is tracked: x component" STEERABLE=ALWAYS
 {
   "^$" :: "No tracking, or fixed value."
   "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[[0-9]+\])?" :: "name of a grid scalar"
 } ""
 
-# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_y[10] "Grid scalar that is tracked: y component" STEERABLE=ALWAYS
 {
   "^$" :: "No tracking, or fixed value."
   "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[[0-9]+\])?" :: "name of a grid scalar"
 } ""
 
-# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_z[10] "Grid scalar that is tracked: z component" STEERABLE=ALWAYS
 {
   "^$" :: "No tracking, or fixed value."

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -1,0 +1,70 @@
+# Parameter definitions for thorn TargetTracker
+
+INT nmax_targets "clutch parameter for the maximum number of targets"
+{
+  10
+} 10
+
+BOOLEAN track[10] "Track this target" STEERABLE=ALWAYS
+{
+} "no"
+
+STRING target_x[10] "Grid scalar that is tracked: x component" STEERABLE=ALWAYS
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+STRING target_y[10] "Grid scalar that is tracked: y component" STEERABLE=ALWAYS
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+STRING target_z[10] "Grid scalar that is tracked: z component" STEERABLE=ALWAYS
+{
+  "" :: "don't use this feature"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
+} ""
+
+INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate. In-run updates of other steerable parameters will occur after this is checked." STEERABLE=ALWAYS
+{
+  1:* :: "Any positive integer"
+} 1
+
+REAL start_tracking_after_time[10] "Start tracking at the given time" STEERABLE=ALWAYS
+{
+  *:* :: "after this time (inclusively)"
+} 0.0
+
+REAL stop_tracking_after_time[10] "Stop tracking after the given time" STEERABLE=ALWAYS
+{
+  *:* :: "after this time (exclusively)"
+} 1e+99
+
+INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location"
+{
+  -1  :: "don't store target location"
+  0:* :: "any spherical surface index"
+} -1
+
+REAL initial_x[10] "Initial x coordinate positions of targets"
+{
+  *:* :: ""
+} 0.0
+
+REAL initial_y[10] "Initial y coordinate positions of targets"
+{
+  *:* :: ""
+} 0.0
+
+REAL initial_z[10] "Initial z coordinate positions of targets"
+{
+  *:* :: ""
+} 0.0
+
+BOOLEAN verbose "Print tracking status messages" STEERABLE=ALWAYS
+{
+} "no"
+
+

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -18,26 +18,23 @@ BOOLEAN track[10] "Track this target" STEERABLE=ALWAYS
 # Splitting the grid scalar names in two cases for legibility and portability
 STRING target_x[10] "Grid scalar that is tracked: x component" STEERABLE=ALWAYS
 {
-  "fixed" :: "No target, or fixed value."
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
-} "fixed"
+  "^$" :: "No tracking, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[[0-9]+\])?" :: "name of a grid scalar"
+} ""
 
 # Splitting the grid scalar names in two cases for legibility and portability
 STRING target_y[10] "Grid scalar that is tracked: y component" STEERABLE=ALWAYS
 {
-  "fixed" :: "No target, or fixed value."
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
-} "fixed"
+  "^$" :: "No tracking, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[[0-9]+\])?" :: "name of a grid scalar"
+} ""
 
 # Splitting the grid scalar names in two cases for legibility and portability
 STRING target_z[10] "Grid scalar that is tracked: z component" STEERABLE=ALWAYS
 {
-  "fixed" :: "No target, or fixed value."
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
-} "fixed"
+  "^$" :: "No tracking, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[[0-9]+\])?" :: "name of a grid scalar"
+} ""
 
 INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate tracking. In-run updates of other steerable parameters will occur after the iteration number is checked." STEERABLE=RECOVER
 {

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -15,6 +15,10 @@ BOOLEAN track[10] "Track this target" STEERABLE=ALWAYS
 {
 } "no"
 
+BOOLEAN loc_from_surface_mode[10] "Instead of tracking a scalar and set the surface accordingly, feed the surface coordinates into target_loc. Can be useful for continuity when a horizon is formed for instance." STEERABLE=ALWAYS
+{
+} "no"
+
 # Splitting the grid scalar names in two cases for legibility and portability
 STRING target_x[10] "Grid scalar that is tracked: x component" STEERABLE=ALWAYS
 {

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -7,6 +7,10 @@ INT nmax_targets "crutch parameter for the maximum number of targets"
   10
 } 10
 
+BOOLEAN force_params_at_recovery[10] "When recovering from a checkpoint, set the surfaces with values from the parameter file, instead of the checkpoint. See documentation for caveats." STEERABLE=RECOVER
+{
+} "no"
+
 BOOLEAN track[10] "Track this target" STEERABLE=ALWAYS
 {
 } "no"
@@ -35,22 +39,22 @@ STRING target_z[10] "Grid scalar that is tracked: z component" STEERABLE=ALWAYS
   "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
 } "fixed"
 
-INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate tracking. In-run updates of other steerable parameters will occur after the iteration number is checked." STEERABLE=ALWAYS
+INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate tracking. In-run updates of other steerable parameters will occur after the iteration number is checked." STEERABLE=RECOVER
 {
   1:* :: "Any positive integer"
 } 1
 
-REAL start_tracking_after_time[10] "Start tracking at the given time" STEERABLE=ALWAYS
+REAL start_tracking_after_time[10] "Start tracking at the given time" STEERABLE=RECOVER
 {
   *:* :: "after this time (inclusively)"
 } 0.0
 
-REAL stop_tracking_after_time[10] "Stop tracking after the given time" STEERABLE=ALWAYS
+REAL stop_tracking_after_time[10] "Stop tracking after the given time" STEERABLE=RECOVER
 {
   *:* :: "after this time (exclusively)"
 } 1e+99
 
-INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location. Make sure you have created the surface!" STEERABLE=ALWAYS
+INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location. Make sure you have created the surface!"
 {
   -1  :: "don't store target location"
   0:* :: "any spherical surface index"

--- a/TargetTracker/param.ccl
+++ b/TargetTracker/param.ccl
@@ -1,6 +1,8 @@
 # Parameter definitions for thorn TargetTracker
 
-INT nmax_targets "clutch parameter for the maximum number of targets"
+# This could be turned into a public parameter with range, setting the number of targets
+# (like nsurfaces for SphericalSurface)
+INT nmax_targets "crutch parameter for the maximum number of targets"
 {
   10
 } 10
@@ -9,25 +11,31 @@ BOOLEAN track[10] "Track this target" STEERABLE=ALWAYS
 {
 } "no"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_x[10] "Grid scalar that is tracked: x component" STEERABLE=ALWAYS
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_y[10] "Grid scalar that is tracked: y component" STEERABLE=ALWAYS
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
+# Splitting the grid scalar names in two cases for legibility and portability
 STRING target_z[10] "Grid scalar that is tracked: z component" STEERABLE=ALWAYS
 {
-  "" :: "don't use this feature"
-  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*(\[0-9+\])" :: "name of a grid scalar"
-} ""
+  "fixed" :: "No target, or fixed value."
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*"                :: "name of a grid scalar without index"
+  "[a-zA-Z_][a-zA-Z0-9_]*[:][:][a-zA-Z_][a-zA-Z0-9_]*\[[0-9][0-9]*\]" :: "name of a grid scalar with index"
+} "fixed"
 
-INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate. In-run updates of other steerable parameters will occur after this is checked." STEERABLE=ALWAYS
+INT track_every[10] "Track target every N iterations. Use parameter `track` to (de)activate tracking. In-run updates of other steerable parameters will occur after the iteration number is checked." STEERABLE=ALWAYS
 {
   1:* :: "Any positive integer"
 } 1
@@ -42,23 +50,23 @@ REAL stop_tracking_after_time[10] "Stop tracking after the given time" STEERABLE
   *:* :: "after this time (exclusively)"
 } 1e+99
 
-INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location"
+INT which_surface_to_store_info[10] "A spherical surface index where we can store the target location. Make sure you have created the surface!" STEERABLE=ALWAYS
 {
   -1  :: "don't store target location"
   0:* :: "any spherical surface index"
 } -1
 
-REAL initial_x[10] "Initial x coordinate positions of targets"
+REAL initial_x[10] "Initial x coordinate positions of targets" STEERABLE=RECOVER
 {
   *:* :: ""
 } 0.0
 
-REAL initial_y[10] "Initial y coordinate positions of targets"
+REAL initial_y[10] "Initial y coordinate positions of targets" STEERABLE=RECOVER
 {
   *:* :: ""
 } 0.0
 
-REAL initial_z[10] "Initial z coordinate positions of targets"
+REAL initial_z[10] "Initial z coordinate positions of targets" STEERABLE=RECOVER
 {
   *:* :: ""
 } 0.0
@@ -68,3 +76,6 @@ BOOLEAN verbose "Print tracking status messages" STEERABLE=ALWAYS
 } "no"
 
 
+SHARES: SphericalSurface
+
+USES CCTK_INT nsurfaces

--- a/TargetTracker/schedule.ccl
+++ b/TargetTracker/schedule.ccl
@@ -1,5 +1,6 @@
 # Schedule definitions for thorn TargetTracker
 
+storage: is_tracked[1]
 storage: is_active[1]
 storage: target_loc[1]
 storage: target_ids[1]
@@ -10,11 +11,19 @@ schedule TargetTracker_ParamCheck AT ParamCheck
   OPTIONS: global
 } "Check TargetTracker parameters for consistency"
 
-schedule TargetTracker_Initialization at BASEGRID
+# First initialization
+schedule TargetTracker_Initialization at INITIAL
 {
   LANG: C
   OPTIONS: global
 } "Initialize TargetTracker quantities"
+
+# Update parameters at recovery
+schedule TargetTracker_Recovery at CCTK_POST_RECOVER_VARIABLES
+{
+  LANG: C
+  OPTIONS: global
+} "(Partial) recovery of parameters from checkpointed internal variables"
 
 schedule TargetTracker_SetSurfaces at ANALYSIS after Trigger_Check
 {

--- a/TargetTracker/schedule.ccl
+++ b/TargetTracker/schedule.ccl
@@ -1,8 +1,22 @@
 # Schedule definitions for thorn TargetTracker
 
+storage: is_active[1]
 storage: target_loc[1]
+storage: target_ids[1]
 
-schedule TargetTracker_SetSurfaces at ANALYSIS
+schedule TargetTracker_ParamCheck AT ParamCheck
+{
+  LANG: C
+  OPTIONS: global
+} "Check TargetTracker parameters for consistency"
+
+schedule TargetTracker_Initialization at BASEGRID
+{
+  LANG: C
+  OPTIONS: global
+} "Initialize TargetTracker quantities"
+
+schedule TargetTracker_SetSurfaces at ANALYSIS after Trigger_Check
 {
   LANG: C
   OPTIONS: global

--- a/TargetTracker/schedule.ccl
+++ b/TargetTracker/schedule.ccl
@@ -2,6 +2,7 @@
 
 storage: is_tracked[1]
 storage: is_active[1]
+storage: is_loc_from_surface[1]
 storage: target_loc[1]
 storage: target_ids[1]
 

--- a/TargetTracker/schedule.ccl
+++ b/TargetTracker/schedule.ccl
@@ -1,0 +1,9 @@
+# Schedule definitions for thorn TargetTracker
+
+storage: target_loc[1]
+
+schedule TargetTracker_SetSurfaces at ANALYSIS
+{
+  LANG: C
+  OPTIONS: global
+} "Update tracked points coordinates"

--- a/TargetTracker/src/Initialization.c
+++ b/TargetTracker/src/Initialization.c
@@ -23,16 +23,31 @@ void InitializeOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
     // z source
     target_id_z[itarget] = CCTK_VarIndex (target_z[itarget]);
 
-    // initial position
+    // Initial position
+    // Will be overriden with the correct values at ANALYSIS if needed 
     target_loc_x[itarget] = initial_x[itarget];
     target_loc_y[itarget] = initial_y[itarget];
     target_loc_z[itarget] = initial_z[itarget];
-
+    
+    // Set initial value of is_loc_from_surface flag.
+    // ParamCheck prevents a wrong surface index here.
+    // TargetActivationCondtion will repeat it, 
+    // but doing it once here allows to avoid triggering the change message.
+    is_loc_from_surface[itarget] = loc_from_surface_mode[itarget];
+    
     // Set initial active status of the target based on the current parameters.
     TargetActivationCondition(CCTK_PASS_CTOC, itarget);
     
     if (is_tracked[itarget]) {
         
+        if (which_surface_to_store_info[itarget] != -1) {
+            char* from_surf_str = loc_from_surface_mode[itarget] ? 
+                                "'surface to tracker'" : 
+                                "'tracker to surface'" ;
+            CCTK_VINFO("Tracker %d associated with surface %d is in %s mode.", 
+                        itarget, which_surface_to_store_info[itarget], from_surf_str);
+        }
+
         CCTK_VINFO("Initialized %s target %d with sources:", is_active[itarget] ? "active" : "inactive", itarget);
         
         // Check if fixed target in each dimension
@@ -115,6 +130,8 @@ void RecoverOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
     
     // The ParameterSet will take effect at the next DECLARE_CCTK_PARAMETERS
 
+    char param_name[100];
+
     /* Parameter: track 
      * Most important to recover since it controls the tracking and is always steerable.
      */
@@ -133,9 +150,31 @@ void RecoverOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
         }
     }
     // Set
-    char param_name[100];
     sprintf(param_name, "track[%d]", itarget);
     CCTK_ParameterSet(param_name, "TargetTracker", is_tracked[itarget] ? "yes" : "no");
+
+    //////////////////////////////////////////////
+    
+    /* Parameter: loc_from_surface_mode
+     * Controls the tracking mode and is always steerable.
+     */
+    // Info
+    if (loc_from_surface_mode[itarget] != is_loc_from_surface[itarget]) {
+        char message[1000];
+        sprintf(message, "At recovery of target %d, parameter 'loc_from_surface_mode' is '%s', but the internal flag 'is_loc_from_surface' is '%s'.\n"
+                         "    Setting loc_from_surface_mode[%d] = %s.",
+                         itarget, loc_from_surface_mode[itarget] ? "yes" : "no", is_loc_from_surface[itarget] ? "yes" : "no",
+                         itarget, is_loc_from_surface[itarget] ? "yes" : "no");
+        if (verbose) {
+            CCTK_VINFO("%s", message);
+        }
+        else {
+            CCTK_VWARN(CCTK_WARN_COMPLAIN, "%s", message);
+        }
+    }
+    // Set
+    sprintf(param_name, "loc_from_surface_mode[%d]", itarget);
+    CCTK_ParameterSet(param_name, "TargetTracker", is_loc_from_surface[itarget] ? "yes" : "no");
 
     //////////////////////////////////////////////
 

--- a/TargetTracker/src/Initialization.c
+++ b/TargetTracker/src/Initialization.c
@@ -31,7 +31,7 @@ void InitializeOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
     
     // Set initial value of is_loc_from_surface flag.
     // ParamCheck prevents a wrong surface index here.
-    // TargetActivationCondtion will repeat it, 
+    // TargetActivationCondition will repeat it, 
     // but doing it once here allows to avoid triggering the change message.
     is_loc_from_surface[itarget] = loc_from_surface_mode[itarget];
     
@@ -195,7 +195,7 @@ void RecoverOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
      * - force_params_at_recovery: STEERABLE=RECOVER
      * - track_every: STEERABLE=RECOVER
      * - start/stop_tracking_after_time: STEERABLE=RECOVER
-     * - which_surface_to_store_info: STEERABLE=NEVER
+     * - which_surface_to_store_info: STEERABLE=RECOVER
      * - initial_x/y/z: STEERABLE=RECOVER, and they are ignored anyway if force_params_at_recovery = no
      * - verbose: STEERABLE=ALWAYS, but it's not critical (and the user should know if they try to steer it mid-run)
      */

--- a/TargetTracker/src/Initialization.c
+++ b/TargetTracker/src/Initialization.c
@@ -12,7 +12,7 @@ void InitializeOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
 
     // Get the index of variables. It's not supposed to change during the simulation (I think).
     // Validity of parameters should have been checked in ParamCheck.
-    // Since validity has been checked, we can use the negative return value for "fixed" targets.
+    // Since validity has been checked, a negative value here should mean fixed tracker (empty string "^$").
     // WARNING: Since the parameters are steerable, make sure the rest is robust
     
     
@@ -77,14 +77,14 @@ void RecoverOneTargetNameOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOn
         sprintf(checkpointed_Name, "%s::%s", CCTK_ImpFromVarI(*ptr_current_id), CCTK_VarName(*ptr_current_id));
     }
     else {
-        sprintf(checkpointed_Name, "fixed");
+        sprintf(checkpointed_Name, "%s", "");
     }
 
     // Output info
     if (recovery_ID != *ptr_current_id || !CCTK_Equals(tgt_name, checkpointed_Name)) {
         char message[1000];
         sprintf(message, "At recovery of target %d, parameter 'target_%s' is '%s' (ID: %d),\n"
-                         "    but the variable with chekcpointed index 'target_id_%s[%d]' = %d is '%s'.\n"
+                         "    but the variable with checkpointed index 'target_id_%s[%d]' = %d is '%s'.\n"
                          "    Setting target_%s[%d] = %s.",
                          itarget, dim_name, tgt_name, recovery_ID,
                          dim_name, itarget, *ptr_current_id, checkpointed_Name,
@@ -95,14 +95,14 @@ void RecoverOneTargetNameOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOn
         else {
             CCTK_VWARN(CCTK_WARN_COMPLAIN, "%s", message);
         }
-    } //enf if mismatch
+    } //end if mismatch
 
     // Set parameter to checkpointed value
     // A recovered negative index should mean a fixed target
     // The ParameterSet will take effect at the next DECLARE_CCTK_PARAMETERS
     char param_name[100];
     sprintf(param_name, "target_%s[%d]", dim_name, itarget);
-    CCTK_ParameterSet(param_name, "TargetTracker", (*ptr_current_id >= 0) ? checkpointed_Name : "fixed");
+    CCTK_ParameterSet(param_name, "TargetTracker", (*ptr_current_id >= 0) ? checkpointed_Name : "");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ void RecoverOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
 
     /* Parameters: target variables
      * We recover the names from their checkpointed IDs.
-     * NOTE: If these parameters become not always steerable, this step is probably unncessary.
+     * NOTE: If these parameters become not always steerable, this step is probably unnecessary.
      */
     const struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
     RecoverOneTargetNameOneDim(CCTK_PASS_CTOC, bundle_x);

--- a/TargetTracker/src/Initialization.c
+++ b/TargetTracker/src/Initialization.c
@@ -3,12 +3,13 @@
 #include <cctk_Parameters.h>
 #include "TargetTracker.h"
 
-void TargetTracker_Initialization(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTS;
-  DECLARE_CCTK_PARAMETERS;
+///////////////////////////////////////////////////////////////////////////////
+// First initialization of one target
+///////////////////////////////////////////////////////////////////////////////
+void InitializeOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
 
-  // Initialize targets
-  for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
     // Get the index of variables. It's not supposed to change during the simulation (I think).
     // Validity of parameters should have been checked in ParamCheck.
     // Since validity has been checked, we can use the negative return value for "fixed" targets.
@@ -30,31 +31,177 @@ void TargetTracker_Initialization(CCTK_ARGUMENTS) {
     // Set initial active status of the target based on the current parameters.
     TargetActivationCondition(CCTK_PASS_CTOC, itarget);
     
-    if (track[itarget]) {
-      
-      CCTK_VINFO("Initialized %s target %d with sources:", is_active[itarget] ? "active" : "inactive", itarget);
-      
-      // Check if fixed target in each dimension
+    if (is_tracked[itarget]) {
+        
+        CCTK_VINFO("Initialized %s target %d with sources:", is_active[itarget] ? "active" : "inactive", itarget);
+        
+        // Check if fixed target in each dimension
 
-      if (target_id_x[itarget] >= 0) {
-        CCTK_VINFO("x: %s", target_x[itarget]);
-      } else {
-        CCTK_VINFO("x = %g (fixed)", initial_x[itarget]);
-      }
+        if (target_id_x[itarget] >= 0) {
+            CCTK_VINFO("x: %s", target_x[itarget]);
+        } else {
+            CCTK_VINFO("x = %g (fixed)", initial_x[itarget]);
+        }
 
-      if (target_id_y[itarget] >= 0) {
-        CCTK_VINFO("y: %s", target_y[itarget]);
-      } else {
-        CCTK_VINFO("y = %g (fixed)", initial_y[itarget]);
-      }
+        if (target_id_y[itarget] >= 0) {
+            CCTK_VINFO("y: %s", target_y[itarget]);
+        } else {
+            CCTK_VINFO("y = %g (fixed)", initial_y[itarget]);
+        }
 
-      if (target_id_z[itarget] >= 0) {
-        CCTK_VINFO("z: %s", target_z[itarget]);
-      } else {
-        CCTK_VINFO("z = %g (fixed)", initial_z[itarget]);
-      }
+        if (target_id_z[itarget] >= 0) {
+            CCTK_VINFO("z: %s", target_z[itarget]);
+        } else {
+            CCTK_VINFO("z = %g (fixed)", initial_z[itarget]);
+        }
 
     } // end if track
+}
 
-  } // for itarget
+///////////////////////////////////////////////////////////////////////////////
+// Helper function to recover the name of the target variable for one dimension (x, y, z) from its checkpointed ID.
+///////////////////////////////////////////////////////////////////////////////
+void RecoverOneTargetNameOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOneDim bundle) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    // Unpack bundle
+    const CCTK_INT itarget          = bundle.itarget;
+    const CCTK_INT* ptr_current_id  = bundle.ptr_current_id;
+    const char* tgt_name            = bundle.tgt_name;
+    const char* dim_name            = bundle.dim_name;
+
+    const CCTK_INT recovery_ID      = CCTK_VarIndex (tgt_name);
+    char checkpointed_Name[150];
+    if (*ptr_current_id >= 0) {
+        sprintf(checkpointed_Name, "%s::%s", CCTK_ImpFromVarI(*ptr_current_id), CCTK_VarName(*ptr_current_id));
+    }
+    else {
+        sprintf(checkpointed_Name, "fixed");
+    }
+
+    // Output info
+    if (recovery_ID != *ptr_current_id || !CCTK_Equals(tgt_name, checkpointed_Name)) {
+        char message[1000];
+        sprintf(message, "At recovery of target %d, parameter 'target_%s' is '%s' (ID: %d),\n"
+                         "    but the variable with chekcpointed index 'target_id_%s[%d]' = %d is '%s'.\n"
+                         "    Setting target_%s[%d] = %s.",
+                         itarget, dim_name, tgt_name, recovery_ID,
+                         dim_name, itarget, *ptr_current_id, checkpointed_Name,
+                         dim_name, itarget, checkpointed_Name);
+        if (verbose) {
+            CCTK_VINFO("%s", message);
+        }
+        else {
+            CCTK_VWARN(CCTK_WARN_COMPLAIN, "%s", message);
+        }
+    } //enf if mismatch
+
+    // Set parameter to checkpointed value
+    // A recovered negative index should mean a fixed target
+    // The ParameterSet will take effect at the next DECLARE_CCTK_PARAMETERS
+    char param_name[100];
+    sprintf(param_name, "target_%s[%d]", dim_name, itarget);
+    CCTK_ParameterSet(param_name, "TargetTracker", (*ptr_current_id >= 0) ? checkpointed_Name : "fixed");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// (Partial) recovery of parameters for one target (after restart from checkpoint)
+// This is not completely robust for all parameters and all scenarios.
+///////////////////////////////////////////////////////////////////////////////
+void RecoverOneTarget (CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+    
+    // The ParameterSet will take effect at the next DECLARE_CCTK_PARAMETERS
+
+    /* Parameter: track 
+     * Most important to recover since it controls the tracking and is always steerable.
+     */
+    // Info
+    if (track[itarget] != is_tracked[itarget]) {
+        char message[1000];
+        sprintf(message, "At recovery of target %d, parameter 'track' is '%s', but the internal flag 'is_tracked' is '%s'.\n"
+                         "    Setting track[%d] = %s.",
+                         itarget, track[itarget] ? "yes" : "no", is_tracked[itarget] ? "yes" : "no",
+                         itarget, is_tracked[itarget] ? "yes" : "no");
+        if (verbose) {
+            CCTK_VINFO("%s", message);
+        }
+        else {
+            CCTK_VWARN(CCTK_WARN_COMPLAIN, "%s", message);
+        }
+    }
+    // Set
+    char param_name[100];
+    sprintf(param_name, "track[%d]", itarget);
+    CCTK_ParameterSet(param_name, "TargetTracker", is_tracked[itarget] ? "yes" : "no");
+
+    //////////////////////////////////////////////
+
+    /* Parameters: target variables
+     * We recover the names from their checkpointed IDs.
+     * NOTE: If these parameters become not always steerable, this step is probably unncessary.
+     */
+    const struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
+    RecoverOneTargetNameOneDim(CCTK_PASS_CTOC, bundle_x);
+    const struct TargetInfoBundleOneDim bundle_y = {itarget, &target_id_y[itarget], target_y[itarget], "y"};
+    RecoverOneTargetNameOneDim(CCTK_PASS_CTOC, bundle_y);
+    const struct TargetInfoBundleOneDim bundle_z = {itarget, &target_id_z[itarget], target_z[itarget], "z"};
+    RecoverOneTargetNameOneDim(CCTK_PASS_CTOC, bundle_z);
+
+    //////////////////////////////////////////////
+
+    /* Parameters that we don't try to recover:
+     * - force_params_at_recovery: STEERABLE=RECOVER
+     * - track_every: STEERABLE=RECOVER
+     * - start/stop_tracking_after_time: STEERABLE=RECOVER
+     * - which_surface_to_store_info: STEERABLE=NEVER
+     * - initial_x/y/z: STEERABLE=RECOVER, and they are ignored anyway if force_params_at_recovery = no
+     * - verbose: STEERABLE=ALWAYS, but it's not critical (and the user should know if they try to steer it mid-run)
+     */
+
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Routine called at the first initialization of the simulation (i.e. not recovery)
+///////////////////////////////////////////////////////////////////////////////
+void TargetTracker_Initialization(CCTK_ARGUMENTS) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
+        InitializeOneTarget(CCTK_PASS_CTOC, itarget);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Routine called at recovery
+///////////////////////////////////////////////////////////////////////////////
+void TargetTracker_Recovery(CCTK_ARGUMENTS) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    /* Fundamental ambiguity: have parameters changed during the run and the parameter is reused identically,
+     * or has the user purposefully changed the parameter file?
+     * Having a fully consistent and robust architecture seems involved, so we have to make assumptions and concessions.
+     *
+     * By default, we want to keep the recovered parameters, but without having to fully duplicate parameters into the interface.
+     * (I don't fully understand if we can get the checkpointed values of (steerable) parameters and store them somehow.)
+     * The user can force a re-read of parameters at recovery (for those that we try to infer).
+     */
+    
+    for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
+        if (force_params_at_recovery[itarget]) {
+            if (verbose) {
+                CCTK_VINFO("Forcing re-initialization of target %d from parameter file at recovery.", itarget);
+            }
+            InitializeOneTarget(CCTK_PASS_CTOC, itarget);
+        }
+        else {
+            RecoverOneTarget(CCTK_PASS_CTOC, itarget);
+        }
+    }
 }

--- a/TargetTracker/src/Initialization.c
+++ b/TargetTracker/src/Initialization.c
@@ -1,0 +1,60 @@
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+#include "TargetTracker.h"
+
+void TargetTracker_Initialization(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  // Initialize targets
+  for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
+    // Get the index of variables. It's not supposed to change during the simulation (I think).
+    // Validity of parameters should have been checked in ParamCheck.
+    // Since validity has been checked, we can use the negative return value for "fixed" targets.
+    // WARNING: Since the parameters are steerable, make sure the rest is robust
+    
+    
+    // x source
+    target_id_x[itarget] = CCTK_VarIndex (target_x[itarget]);
+    // y source
+    target_id_y[itarget] = CCTK_VarIndex (target_y[itarget]);
+    // z source
+    target_id_z[itarget] = CCTK_VarIndex (target_z[itarget]);
+
+    // initial position
+    target_loc_x[itarget] = initial_x[itarget];
+    target_loc_y[itarget] = initial_y[itarget];
+    target_loc_z[itarget] = initial_z[itarget];
+
+    // Set initial active status of the target based on the current parameters.
+    TargetActivationCondition(CCTK_PASS_CTOC, itarget);
+    
+    if (track[itarget]) {
+      
+      CCTK_VINFO("Initialized %s target %d with sources:", is_active[itarget] ? "active" : "inactive", itarget);
+      
+      // Check if fixed target in each dimension
+
+      if (target_id_x[itarget] >= 0) {
+        CCTK_VINFO("x: %s", target_x[itarget]);
+      } else {
+        CCTK_VINFO("x = %g (fixed)", initial_x[itarget]);
+      }
+
+      if (target_id_y[itarget] >= 0) {
+        CCTK_VINFO("y: %s", target_y[itarget]);
+      } else {
+        CCTK_VINFO("y = %g (fixed)", initial_y[itarget]);
+      }
+
+      if (target_id_z[itarget] >= 0) {
+        CCTK_VINFO("z: %s", target_z[itarget]);
+      } else {
+        CCTK_VINFO("z = %g (fixed)", initial_z[itarget]);
+      }
+
+    } // end if track
+
+  } // for itarget
+}

--- a/TargetTracker/src/ParamCheck.c
+++ b/TargetTracker/src/ParamCheck.c
@@ -8,6 +8,10 @@ void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
 
     for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
         
+        if (loc_from_surface_mode[itarget] && which_surface_to_store_info[itarget] == -1) {
+            CCTK_VPARAMWARN("For target %d, 'loc_from_surface_mode' is yes but no surface is specified in 'which_surface_to_store_info'.", itarget);
+        }
+
         if (which_surface_to_store_info[itarget] != -1 && which_surface_to_store_info[itarget] >= nsurfaces) {
             CCTK_VPARAMWARN("For target %d, surface index is greater than the number of spherical surfaces.", itarget);
         }

--- a/TargetTracker/src/ParamCheck.c
+++ b/TargetTracker/src/ParamCheck.c
@@ -19,7 +19,7 @@ void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
         CCTK_INT index;
         // x
         index = CCTK_VarIndex (target_x[itarget]);
-        if (!CCTK_Equals(target_x[itarget], "fixed")) {
+        if (!CCTK_Equals(target_x[itarget], "")) {
             if (index < 0) {
                 CCTK_VPARAMWARN("Could not get index of target %d x variable: %s.", itarget, target_x[itarget]);
             }
@@ -29,7 +29,7 @@ void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
         }
         // y
         index = CCTK_VarIndex (target_y[itarget]);
-        if (!CCTK_Equals(target_y[itarget], "fixed")) {
+        if (!CCTK_Equals(target_y[itarget], "")) {
             if (index < 0) {
                 CCTK_VPARAMWARN("Could not get index of target %d y variable: %s.", itarget, target_y[itarget]);
             }
@@ -39,7 +39,7 @@ void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
         }
         // z
         index = CCTK_VarIndex (target_z[itarget]);
-        if (!CCTK_Equals(target_z[itarget], "fixed")) {
+        if (!CCTK_Equals(target_z[itarget], "")) {
             if (index < 0) {
                 CCTK_VPARAMWARN("Could not get index of target %d z variable: %s.", itarget, target_z[itarget]);
             }

--- a/TargetTracker/src/ParamCheck.c
+++ b/TargetTracker/src/ParamCheck.c
@@ -1,0 +1,51 @@
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+
+void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_ARGUMENTS;
+  DECLARE_CCTK_PARAMETERS;
+
+  for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
+    
+    if (which_surface_to_store_info[itarget] != -1 && which_surface_to_store_info[itarget] >= nsurfaces) {
+      CCTK_VPARAMWARN("For target %d, surface index is greater than the number of spherical surfaces.", itarget);
+    }
+    
+    
+    // --------------------------------
+    // CHECK TARGET VARIABLES
+    // --------------------------------
+    CCTK_INT index;
+    // x
+    index = CCTK_VarIndex (target_x[itarget]);
+    if (!CCTK_Equals(target_x[itarget], "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of target %d x variable: %s.", itarget, target_x[itarget]);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Target %d x variable: %s is not a grid scalar.", itarget, target_x[itarget]);
+      }
+    }
+    // y
+    index = CCTK_VarIndex (target_y[itarget]);
+    if (!CCTK_Equals(target_y[itarget], "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of target %d y variable: %s.", itarget, target_y[itarget]);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Target %d y variable: %s is not a grid scalar.", itarget, target_y[itarget]);
+      }
+    }
+    // z
+    index = CCTK_VarIndex (target_z[itarget]);
+    if (!CCTK_Equals(target_z[itarget], "fixed")) {
+      if (index < 0) {
+        CCTK_VPARAMWARN("Could not get index of target %d z variable: %s.", itarget, target_z[itarget]);
+      }
+      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+        CCTK_VPARAMWARN("Target %d z variable: %s is not a grid scalar.", itarget, target_z[itarget]);
+      }
+    }
+  }
+}

--- a/TargetTracker/src/ParamCheck.c
+++ b/TargetTracker/src/ParamCheck.c
@@ -3,49 +3,49 @@
 #include <cctk_Parameters.h>
 
 void TargetTracker_ParamCheck(CCTK_ARGUMENTS) {
-  DECLARE_CCTK_ARGUMENTS;
-  DECLARE_CCTK_PARAMETERS;
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
 
-  for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
-    
-    if (which_surface_to_store_info[itarget] != -1 && which_surface_to_store_info[itarget] >= nsurfaces) {
-      CCTK_VPARAMWARN("For target %d, surface index is greater than the number of spherical surfaces.", itarget);
+    for (CCTK_INT itarget = 0; itarget < nmax_targets; itarget++) {
+        
+        if (which_surface_to_store_info[itarget] != -1 && which_surface_to_store_info[itarget] >= nsurfaces) {
+            CCTK_VPARAMWARN("For target %d, surface index is greater than the number of spherical surfaces.", itarget);
+        }
+        
+        
+        // --------------------------------
+        // CHECK TARGET VARIABLES
+        // --------------------------------
+        CCTK_INT index;
+        // x
+        index = CCTK_VarIndex (target_x[itarget]);
+        if (!CCTK_Equals(target_x[itarget], "fixed")) {
+            if (index < 0) {
+                CCTK_VPARAMWARN("Could not get index of target %d x variable: %s.", itarget, target_x[itarget]);
+            }
+            else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+                CCTK_VPARAMWARN("Target %d x variable: %s is not a grid scalar.", itarget, target_x[itarget]);
+            }
+        }
+        // y
+        index = CCTK_VarIndex (target_y[itarget]);
+        if (!CCTK_Equals(target_y[itarget], "fixed")) {
+            if (index < 0) {
+                CCTK_VPARAMWARN("Could not get index of target %d y variable: %s.", itarget, target_y[itarget]);
+            }
+            else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+                CCTK_VPARAMWARN("Target %d y variable: %s is not a grid scalar.", itarget, target_y[itarget]);
+            }
+        }
+        // z
+        index = CCTK_VarIndex (target_z[itarget]);
+        if (!CCTK_Equals(target_z[itarget], "fixed")) {
+            if (index < 0) {
+                CCTK_VPARAMWARN("Could not get index of target %d z variable: %s.", itarget, target_z[itarget]);
+            }
+            else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
+                CCTK_VPARAMWARN("Target %d z variable: %s is not a grid scalar.", itarget, target_z[itarget]);
+            }
+        }
     }
-    
-    
-    // --------------------------------
-    // CHECK TARGET VARIABLES
-    // --------------------------------
-    CCTK_INT index;
-    // x
-    index = CCTK_VarIndex (target_x[itarget]);
-    if (!CCTK_Equals(target_x[itarget], "fixed")) {
-      if (index < 0) {
-        CCTK_VPARAMWARN("Could not get index of target %d x variable: %s.", itarget, target_x[itarget]);
-      }
-      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-        CCTK_VPARAMWARN("Target %d x variable: %s is not a grid scalar.", itarget, target_x[itarget]);
-      }
-    }
-    // y
-    index = CCTK_VarIndex (target_y[itarget]);
-    if (!CCTK_Equals(target_y[itarget], "fixed")) {
-      if (index < 0) {
-        CCTK_VPARAMWARN("Could not get index of target %d y variable: %s.", itarget, target_y[itarget]);
-      }
-      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-        CCTK_VPARAMWARN("Target %d y variable: %s is not a grid scalar.", itarget, target_y[itarget]);
-      }
-    }
-    // z
-    index = CCTK_VarIndex (target_z[itarget]);
-    if (!CCTK_Equals(target_z[itarget], "fixed")) {
-      if (index < 0) {
-        CCTK_VPARAMWARN("Could not get index of target %d z variable: %s.", itarget, target_z[itarget]);
-      }
-      else if (CCTK_GroupTypeFromVarI(index) != CCTK_SCALAR) {
-        CCTK_VPARAMWARN("Target %d z variable: %s is not a grid scalar.", itarget, target_z[itarget]);
-      }
-    }
-  }
 }

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -1,0 +1,185 @@
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+#include <cctk_Functions.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Declare functions to avoid warnings
+////////////////////////////////////////////////////////////////////////////////
+
+// Main function of the TargetTracker thorn
+void TargetTracker_SetSurfaces(CCTK_ARGUMENTS);
+
+// Function to update the is_active status of the target based on the current parameters.
+CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget);
+
+// Wrapper function to change target for one dimension (x, y, z) if it changed
+void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
+                            CCTK_INT *const ptr_current_id, const char* tar_name, 
+                            const char* dim_name);
+
+                            // Helper function to print error message and terminate. Deactivates the concerned target.
+void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget);
+
+
+///////////////////////////////////////////////////////////////////////////////
+// This function updates the is_active status of the target based on the current parameters.
+// It performs checks to see if the target has changed, and if the new one is valid (since it's always steerable).
+///////////////////////////////////////////////////////////////////////////////
+CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+    
+    // Check if the target is tracked
+    is_active[itarget] = ( 
+        track[itarget]
+        // &&  track_every[itarget] > 0     // Should be satisfied by construction
+        &&  (cctk_time >= start_tracking_after_time[itarget])
+        &&  (cctk_time <= stop_tracking_after_time[itarget])
+    );
+    
+    if (is_active[itarget]) {
+        // Check if target has changed and is valid
+        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_x[itarget], target_x[itarget], "x");
+        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_y[itarget], target_y[itarget], "y");
+        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_z[itarget], target_z[itarget], "z");
+    }
+    
+    return is_active[itarget];
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Wrapper function to change target for one dimension (x, y, z) if it changed
+///////////////////////////////////////////////////////////////////////////////
+void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
+                            CCTK_INT *const ptr_current_id, const char* tar_name, 
+                            const char* dim_name) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    // "New" target
+    CCTK_INT tar_id = CCTK_VarIndex(tar_name);
+    if (tar_id != *ptr_current_id) { // Target has changed
+    
+        // Check if new target exists
+        if (tar_id < 0) { // No such variable
+            char error_message [1000]; 
+            sprintf(error_message, "Error while getting ID for target %s variable %s", dim_name, tar_name);
+            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+            return;
+        }
+        
+        // Check if new target is a grid scalar
+        if (CCTK_GroupTypeFromVarI(tar_id) != CCTK_SCALAR) {
+            char error_message [1000];
+            sprintf(error_message, "Target %s variable %s is not a grid scalar.", dim_name, tar_name);
+            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+            return;
+        }
+        
+        // Target is valid: update target_id
+        if (verbose) {
+            CCTK_VINFO("At iteration %d (simulation time %g), target %d %s component was successfully changed from '%s' to '%s'", 
+                cctk_iteration, cctk_time,
+                itarget, dim_name,
+                CCTK_VarName(*ptr_current_id),
+                tar_name
+            );
+        }
+        *ptr_current_id = tar_id;
+    }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// This is the main function of the TargetTracker thorn. 
+// It loops over all targets and performs tracking for those that are active during the current iteration.
+///////////////////////////////////////////////////////////////////////////////
+void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
+{
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+    
+    for (CCTK_INT itarget=0 ; itarget < nmax_targets ; itarget++) {
+
+        // Perform tracking for this target
+        // WARNING: Bypass update if we're not on a tracking iteration
+        // track_every should be > 0 by construction
+        if (cctk_iteration % track_every[itarget] == 0 && UpdateTargetStatus(CCTK_PASS_CTOC, itarget)) { // process iteration
+
+            // Acquire pointer to target variable
+            CCTK_REAL *target_loc_x_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_x[itarget]);
+            CCTK_REAL *target_loc_y_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_y[itarget]);
+            CCTK_REAL *target_loc_z_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_z[itarget]);
+
+            CCTK_INT target_err = 0;
+            if (target_loc_x_ptr == NULL) {
+                char error_message [1000];
+                sprintf(error_message, "Error while acquiring pointer to target %d x variable %s", itarget, target_x[itarget]);
+                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+                ++target_err;
+            }
+            else {
+                *target_loc_x = *target_loc_x_ptr;
+            }
+
+            if (target_loc_y_ptr == NULL) {
+                char error_message [1000];
+                sprintf(error_message, "Error while acquiring pointer to target %d y variable %s", itarget, target_y[itarget]);
+                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+                ++target_err;
+            }
+            else {
+                *target_loc_y = *target_loc_y_ptr;
+            }
+
+            if (target_loc_z_ptr == NULL) {
+                char error_message [1000];
+                sprintf(error_message, "Error while acquiring pointer to target %d z variable %s", itarget, target_z[itarget]);
+                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+                ++target_err;
+            }
+            else {
+                *target_loc_z = *target_loc_z_ptr;
+            }
+
+            if (target_err > 0) {
+                continue;
+            }
+
+            // Update target position
+            if (which_surface_to_store_info[itarget] != -1) {
+                int sn = which_surface_to_store_info[itarget];
+
+                sf_centroid_x[sn] = *target_loc_x;
+                sf_centroid_y[sn] = *target_loc_y;
+                sf_centroid_z[sn] = *target_loc_z;
+
+                sf_active[sn] = 1;
+                sf_valid[sn] = 1;
+
+                if (verbose) {
+                    CCTK_VINFO("Setting spherical surface %d centroid from target #%d to (%g,%g,%g)",
+                                sn, itarget, 
+                                *target_loc_x, *target_loc_y, *target_loc_z);
+                }
+            }
+        } //end if process iteration
+    } // end for loop over targets
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Helper function to print error message and terminate. Deactivates the concerned target.
+///////////////////////////////////////////////////////////////////////////////
+inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+
+    CCTK_VWARN(1, "%s", message);
+    CCTK_VWARN(1, "Deactivating target %d and triggering termination at iteration %d (simulation time %g).", itarget, cctk_iteration, cctk_time);
+    CCTK_TerminateNext(cctkGH);
+
+    is_active[itarget] = 0;
+    return;
+}

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -2,6 +2,7 @@
 #include <cctk_Arguments.h>
 #include <cctk_Parameters.h>
 #include <cctk_Functions.h>
+#include "TargetTracker.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Declare functions to avoid warnings
@@ -13,13 +14,15 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS);
 // Function to update the is_active status of the target based on the current parameters.
 CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget);
 
-// Wrapper function to change target for one dimension (x, y, z) if it changed
+// Helper function to check a change of target for one dimension (x, y, z)
 void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
-                            CCTK_INT *const ptr_current_id, const char* tar_name, 
+                            CCTK_INT *const ptr_current_id, const char* tgt_name, 
                             const char* dim_name);
 
-                            // Helper function to print error message and terminate. Deactivates the concerned target.
-void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget);
+// Helper function to get data for pointer in one dimension (x, y, z)
+CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
+                            CCTK_INT tgt_id, const char* tgt_name,
+                            CCTK_REAL *const ptr_target_loc, const char* dim_name);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,16 +33,20 @@ CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
     DECLARE_CCTK_ARGUMENTS;
     DECLARE_CCTK_PARAMETERS;
     
-    // Check if the target is tracked
-    is_active[itarget] = ( 
-        track[itarget]
-        // &&  track_every[itarget] > 0     // Should be satisfied by construction
-        &&  (cctk_time >= start_tracking_after_time[itarget])
-        &&  (cctk_time <= stop_tracking_after_time[itarget])
-    );
+    // Check if the target was tracked previously
+    CCTK_INT was_active = is_active[itarget];
+
+    // Check if the target is tracked now
+    TargetActivationCondition(CCTK_PASS_CTOC, itarget);
+
+    // Info
+    if (verbose && is_active[itarget] != was_active) {
+        CCTK_VINFO("At iteration %d (simulation time %g), target %d was %sactivated.", 
+            cctk_iteration, cctk_time, itarget, is_active[itarget] ? "" : "de");
+    }
     
+    // Check if target has changed and is valid
     if (is_active[itarget]) {
-        // Check if target has changed and is valid
         TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_x[itarget], target_x[itarget], "x");
         TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_y[itarget], target_y[itarget], "y");
         TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_z[itarget], target_z[itarget], "z");
@@ -50,32 +57,36 @@ CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// Wrapper function to change target for one dimension (x, y, z) if it changed
+// Helper function to check a change of target for one dimension (x, y, z)
 ///////////////////////////////////////////////////////////////////////////////
 void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
-                            CCTK_INT *const ptr_current_id, const char* tar_name, 
+                            CCTK_INT *const ptr_current_id, const char* tgt_name, 
                             const char* dim_name) {
     DECLARE_CCTK_ARGUMENTS;
     DECLARE_CCTK_PARAMETERS;
 
     // "New" target
-    CCTK_INT tar_id = CCTK_VarIndex(tar_name);
-    if (tar_id != *ptr_current_id) { // Target has changed
+    CCTK_INT tgt_id = CCTK_VarIndex(tgt_name);
+    if (tgt_id != *ptr_current_id) { // Target has changed
     
-        // Check if new target exists
-        if (tar_id < 0) { // No such variable
-            char error_message [1000]; 
-            sprintf(error_message, "Error while getting ID for target %s variable %s", dim_name, tar_name);
-            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
-            return;
-        }
-        
-        // Check if new target is a grid scalar
-        if (CCTK_GroupTypeFromVarI(tar_id) != CCTK_SCALAR) {
-            char error_message [1000];
-            sprintf(error_message, "Target %s variable %s is not a grid scalar.", dim_name, tar_name);
-            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
-            return;
+        // Check if target is fixed
+        if (!CCTK_Equals(tgt_name, "fixed")) {
+            
+            // Check if new target exists
+            if (tgt_id < 0) { // No such variable
+                char error_message [1000]; 
+                sprintf(error_message, "Could not get index of target %d %s variable %s", itarget, dim_name, tgt_name);
+                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+                return;
+            }
+            
+            // Check if new target is a grid scalar
+            if (CCTK_GroupTypeFromVarI(tgt_id) != CCTK_SCALAR) {
+                char error_message [1000];
+                sprintf(error_message, "Target %d %s variable %s is not a grid scalar.", itarget, dim_name, tgt_name);
+                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+                return;
+            }
         }
         
         // Target is valid: update target_id
@@ -84,11 +95,41 @@ void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
                 cctk_iteration, cctk_time,
                 itarget, dim_name,
                 CCTK_VarName(*ptr_current_id),
-                tar_name
+                tgt_name
             );
         }
-        *ptr_current_id = tar_id;
+        *ptr_current_id = tgt_id;
     }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function to get data for pointer in one dimension (x, y, z)
+// Returns 0 if no error, 1 if error (and deactivates target and triggers termination).
+////////////////////////////////////////////////////////////////////////////////
+CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
+                            CCTK_INT tgt_id, const char* tgt_name,
+                            CCTK_REAL *const ptr_target_loc, const char* dim_name) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    // A negative index here should mean fixed target (and not an error):
+    // keep current position in that case
+    if (tgt_id >= 0) {
+        // Acquire pointer to target variable
+        CCTK_REAL *ptr_new_loc = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, tgt_id);
+        
+        if (ptr_new_loc == NULL) {
+            char error_message [1000];
+            sprintf(error_message, "Error while acquiring pointer to target %d %s variable %s", itarget, dim_name, tgt_name);
+            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+            return 1;
+        }
+        else {
+            *ptr_target_loc = *ptr_new_loc;
+        }
+    }
+    return 0;
 }
 
 
@@ -107,54 +148,25 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
         // WARNING: Bypass update if we're not on a tracking iteration
         // track_every should be > 0 by construction
         if (cctk_iteration % track_every[itarget] == 0 && UpdateTargetStatus(CCTK_PASS_CTOC, itarget)) { // process iteration
-
-            // Acquire pointer to target variable
-            CCTK_REAL *target_loc_x_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_x[itarget]);
-            CCTK_REAL *target_loc_y_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_y[itarget]);
-            CCTK_REAL *target_loc_z_ptr = (CCTK_REAL *) CCTK_VarDataPtrI(cctkGH, 0, target_id_z[itarget]);
-
+            
             CCTK_INT target_err = 0;
-            if (target_loc_x_ptr == NULL) {
-                char error_message [1000];
-                sprintf(error_message, "Error while acquiring pointer to target %d x variable %s", itarget, target_x[itarget]);
-                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
-                ++target_err;
-            }
-            else {
-                *target_loc_x = *target_loc_x_ptr;
-            }
+            // Get target position for each dimension and check for errors
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_x[itarget], target_x[itarget], &target_loc_x[itarget], "x");
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_y[itarget], target_y[itarget], &target_loc_y[itarget], "y");
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_z[itarget], target_z[itarget], &target_loc_z[itarget], "z");
 
-            if (target_loc_y_ptr == NULL) {
-                char error_message [1000];
-                sprintf(error_message, "Error while acquiring pointer to target %d y variable %s", itarget, target_y[itarget]);
-                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
-                ++target_err;
-            }
-            else {
-                *target_loc_y = *target_loc_y_ptr;
-            }
-
-            if (target_loc_z_ptr == NULL) {
-                char error_message [1000];
-                sprintf(error_message, "Error while acquiring pointer to target %d z variable %s", itarget, target_z[itarget]);
-                TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
-                ++target_err;
-            }
-            else {
-                *target_loc_z = *target_loc_z_ptr;
-            }
-
+            // An error will trigger termination at the end of the time step.
             if (target_err > 0) {
                 continue;
             }
 
-            // Update target position
+            // Update spherical surface with target position
             if (which_surface_to_store_info[itarget] != -1) {
                 int sn = which_surface_to_store_info[itarget];
 
-                sf_centroid_x[sn] = *target_loc_x;
-                sf_centroid_y[sn] = *target_loc_y;
-                sf_centroid_z[sn] = *target_loc_z;
+                sf_centroid_x[sn] = target_loc_x[itarget];
+                sf_centroid_y[sn] = target_loc_y[itarget];
+                sf_centroid_z[sn] = target_loc_z[itarget];
 
                 sf_active[sn] = 1;
                 sf_valid[sn] = 1;
@@ -162,24 +174,9 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
                 if (verbose) {
                     CCTK_VINFO("Setting spherical surface %d centroid from target #%d to (%g,%g,%g)",
                                 sn, itarget, 
-                                *target_loc_x, *target_loc_y, *target_loc_z);
+                                target_loc_x[itarget], target_loc_y[itarget], target_loc_z[itarget]);
                 }
             }
         } //end if process iteration
     } // end for loop over targets
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Helper function to print error message and terminate. Deactivates the concerned target.
-///////////////////////////////////////////////////////////////////////////////
-inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget) {
-    DECLARE_CCTK_ARGUMENTS;
-
-    CCTK_VWARN(1, "%s", message);
-    CCTK_VWARN(1, "Deactivating target %d and triggering termination at iteration %d (simulation time %g).", itarget, cctk_iteration, cctk_time);
-    CCTK_TerminateNext(cctkGH);
-
-    is_active[itarget] = 0;
-    return;
 }

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -6,7 +6,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Declare functions to avoid warnings
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 
 // Main function of the TargetTracker thorn
 void TargetTracker_SetSurfaces(CCTK_ARGUMENTS);
@@ -23,6 +23,7 @@ CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOneDi
 
 ///////////////////////////////////////////////////////////////////////////////
 // This function updates the is_active status of the target based on the current parameters.
+// It calls the function that checks parameters and updates the various internal flags.
 // It performs checks to see if the target has changed, and if the new one is valid (since it's always steerable).
 ///////////////////////////////////////////////////////////////////////////////
 CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
@@ -32,10 +33,19 @@ CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
     // Check if the target was tracked previously
     CCTK_INT was_active = is_active[itarget];
 
+    // Check if the tracker was passively following a surface
+    CCTK_INT was_loc_from_surface = is_loc_from_surface[itarget];
+
     // Check if the target is tracked now
     TargetActivationCondition(CCTK_PASS_CTOC, itarget);
 
     // Info
+    if (verbose && is_loc_from_surface[itarget] != was_loc_from_surface) {
+        CCTK_VINFO("At iteration %d (simulation time %g), tracker %d changed to %s mode.", 
+            cctk_iteration, cctk_time, itarget,
+            is_loc_from_surface[itarget] ? "'surface to tracker'" : "'tracker to surface'");
+    }
+
     if (verbose && is_active[itarget] != was_active) {
         CCTK_VINFO("At iteration %d (simulation time %g), target %d was %sactivated.", 
             cctk_iteration, cctk_time, itarget, is_active[itarget] ? "" : "de");
@@ -154,39 +164,61 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
         // Perform tracking for this target
         // WARNING: Bypass update if we're not on a tracking iteration
         // track_every should be > 0 by construction
-        if (cctk_iteration % track_every[itarget] == 0 && UpdateTargetStatus(CCTK_PASS_CTOC, itarget)) { // process iteration
+        if (cctk_iteration % track_every[itarget] == 0) { // process iteration
+            // WARNING: UpdateTargetStatus needs to be called first to update the flags!
+            if (UpdateTargetStatus(CCTK_PASS_CTOC, itarget)) { // active target in tracker to surface mode
             
-            CCTK_INT target_err = 0;
-            // Get target position for each dimension and check for errors
-            struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_x, &target_loc_x[itarget]);
-            struct TargetInfoBundleOneDim bundle_y = {itarget, &target_id_y[itarget], target_y[itarget], "y"};
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_y, &target_loc_y[itarget]);
-            struct TargetInfoBundleOneDim bundle_z = {itarget, &target_id_z[itarget], target_z[itarget], "z"};
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_z, &target_loc_z[itarget]);
+                // Normal case: get target location from variables
+                // In surface to tracker mode, the target is considered inactive
 
-            // An error will trigger termination at the end of the time step.
-            if (target_err > 0) {
-                continue;
-            }
+                CCTK_INT target_err = 0;
+                // Get target position for each dimension and check for errors
+                struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
+                target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_x, &target_loc_x[itarget]);
+                struct TargetInfoBundleOneDim bundle_y = {itarget, &target_id_y[itarget], target_y[itarget], "y"};
+                target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_y, &target_loc_y[itarget]);
+                struct TargetInfoBundleOneDim bundle_z = {itarget, &target_id_z[itarget], target_z[itarget], "z"};
+                target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_z, &target_loc_z[itarget]);
 
-            // Update spherical surface with target position
-            if (which_surface_to_store_info[itarget] != -1) {
-                int sn = which_surface_to_store_info[itarget];
+                // An error will trigger termination at the end of the time step.
+                if (target_err > 0) {
+                    continue;
+                }
 
-                sf_centroid_x[sn] = target_loc_x[itarget];
-                sf_centroid_y[sn] = target_loc_y[itarget];
-                sf_centroid_z[sn] = target_loc_z[itarget];
+                // Update spherical surface with target position
+                if (which_surface_to_store_info[itarget] != -1) {
+                    int sn = which_surface_to_store_info[itarget];
 
-                sf_active[sn] = 1;
-                sf_valid[sn]  = 1;
+                    sf_centroid_x[sn] = target_loc_x[itarget];
+                    sf_centroid_y[sn] = target_loc_y[itarget];
+                    sf_centroid_z[sn] = target_loc_z[itarget];
+
+                    sf_active[sn] = 1;
+                    sf_valid[sn]  = 1;
+
+                    if (verbose) {
+                        CCTK_VINFO("Setting spherical surface %d centroid from target #%d to (%g,%g,%g)",
+                                    sn, itarget, 
+                                    target_loc_x[itarget], target_loc_y[itarget], target_loc_z[itarget]);
+                    }
+                }
+            
+            } else if (is_tracked[itarget] && is_loc_from_surface[itarget]) { // tracked target in surface to tracker mode
+                // If loc_from_surface_mode is on, we don't try to get the target location from the variables,
+                // but directly from the surface. This can be useful for continuity when a horizon is formed for instance.
+                // The case where which_surface_to_store_info is invalid should be caught before
+                
+                // TODO: Check if surface is active / is valid ?
+                target_loc_x[itarget] = sf_centroid_x[which_surface_to_store_info[itarget]];
+                target_loc_y[itarget] = sf_centroid_y[which_surface_to_store_info[itarget]];
+                target_loc_z[itarget] = sf_centroid_z[which_surface_to_store_info[itarget]];
 
                 if (verbose) {
-                    CCTK_VINFO("Setting spherical surface %d centroid from target #%d to (%g,%g,%g)",
-                                sn, itarget, 
+                    CCTK_VINFO("Setting target %d location from surface %d to (%g,%g,%g)",
+                                itarget, which_surface_to_store_info[itarget], 
                                 target_loc_x[itarget], target_loc_y[itarget], target_loc_z[itarget]);
                 }
-            }
+            } // else we don't do anything
         } //end if process iteration
     } // end for loop over targets
 }

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -15,14 +15,10 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS);
 CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget);
 
 // Helper function to check a change of target for one dimension (x, y, z)
-void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
-                            CCTK_INT *const ptr_current_id, const char* tgt_name, 
-                            const char* dim_name);
+void TargetChangeOneDim (CCTK_ARGUMENTS, struct TargetInfoBundleOneDim bundle);
 
 // Helper function to get data for pointer in one dimension (x, y, z)
-CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
-                            CCTK_INT tgt_id, const char* tgt_name,
-                            CCTK_REAL *const ptr_target_loc, const char* dim_name);
+CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOneDim bundle, CCTK_REAL *const ptr_target_loc);
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -47,9 +43,12 @@ CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
     
     // Check if target has changed and is valid
     if (is_active[itarget]) {
-        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_x[itarget], target_x[itarget], "x");
-        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_y[itarget], target_y[itarget], "y");
-        TargetChangeOneDim(CCTK_PASS_CTOC, itarget, &target_id_z[itarget], target_z[itarget], "z");
+        struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
+        TargetChangeOneDim(CCTK_PASS_CTOC, bundle_x);
+        struct TargetInfoBundleOneDim bundle_y = {itarget, &target_id_y[itarget], target_y[itarget], "y"};
+        TargetChangeOneDim(CCTK_PASS_CTOC, bundle_y);
+        struct TargetInfoBundleOneDim bundle_z = {itarget, &target_id_z[itarget], target_z[itarget], "z"};
+        TargetChangeOneDim(CCTK_PASS_CTOC, bundle_z);
     }
     
     return is_active[itarget];
@@ -59,11 +58,15 @@ CCTK_INT UpdateTargetStatus(CCTK_ARGUMENTS, CCTK_INT itarget) {
 ///////////////////////////////////////////////////////////////////////////////
 // Helper function to check a change of target for one dimension (x, y, z)
 ///////////////////////////////////////////////////////////////////////////////
-void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget, 
-                            CCTK_INT *const ptr_current_id, const char* tgt_name, 
-                            const char* dim_name) {
+void TargetChangeOneDim (CCTK_ARGUMENTS, struct TargetInfoBundleOneDim bundle) {
     DECLARE_CCTK_ARGUMENTS;
     DECLARE_CCTK_PARAMETERS;
+
+    // Unpack bundle
+    const CCTK_INT itarget    = bundle.itarget;
+    CCTK_INT* ptr_current_id  = bundle.ptr_current_id;
+    const char* tgt_name      = bundle.tgt_name;
+    const char* dim_name      = bundle.dim_name;
 
     // "New" target
     CCTK_INT tgt_id = CCTK_VarIndex(tgt_name);
@@ -107,11 +110,15 @@ void TargetChangeOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
 // Helper function to get data for pointer in one dimension (x, y, z)
 // Returns 0 if no error, 1 if error (and deactivates target and triggers termination).
 ////////////////////////////////////////////////////////////////////////////////
-CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, CCTK_INT itarget,
-                            CCTK_INT tgt_id, const char* tgt_name,
-                            CCTK_REAL *const ptr_target_loc, const char* dim_name) {
+CCTK_INT TargetGetDataOneDim (CCTK_ARGUMENTS, const struct TargetInfoBundleOneDim bundle, CCTK_REAL *const ptr_target_loc) {
     DECLARE_CCTK_ARGUMENTS;
     DECLARE_CCTK_PARAMETERS;
+
+    // Unpack bundle
+    const CCTK_INT itarget    = bundle.itarget;
+    const CCTK_INT tgt_id     = *bundle.ptr_current_id;
+    const char* tgt_name      = bundle.tgt_name;
+    const char* dim_name      = bundle.dim_name;
 
     // A negative index here should mean fixed target (and not an error):
     // keep current position in that case
@@ -151,9 +158,12 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
             
             CCTK_INT target_err = 0;
             // Get target position for each dimension and check for errors
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_x[itarget], target_x[itarget], &target_loc_x[itarget], "x");
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_y[itarget], target_y[itarget], &target_loc_y[itarget], "y");
-            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, itarget, target_id_z[itarget], target_z[itarget], &target_loc_z[itarget], "z");
+            struct TargetInfoBundleOneDim bundle_x = {itarget, &target_id_x[itarget], target_x[itarget], "x"};
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_x, &target_loc_x[itarget]);
+            struct TargetInfoBundleOneDim bundle_y = {itarget, &target_id_y[itarget], target_y[itarget], "y"};
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_y, &target_loc_y[itarget]);
+            struct TargetInfoBundleOneDim bundle_z = {itarget, &target_id_z[itarget], target_z[itarget], "z"};
+            target_err += TargetGetDataOneDim(CCTK_PASS_CTOC, bundle_z, &target_loc_z[itarget]);
 
             // An error will trigger termination at the end of the time step.
             if (target_err > 0) {

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -179,7 +179,7 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
                 sf_centroid_z[sn] = target_loc_z[itarget];
 
                 sf_active[sn] = 1;
-                sf_valid[sn] = 1;
+                sf_valid[sn]  = 1;
 
                 if (verbose) {
                     CCTK_VINFO("Setting spherical surface %d centroid from target #%d to (%g,%g,%g)",

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -214,7 +214,7 @@ void TargetTracker_SetSurfaces(CCTK_ARGUMENTS)
                 target_loc_z[itarget] = sf_centroid_z[which_surface_to_store_info[itarget]];
 
                 if (verbose) {
-                    CCTK_VINFO("Setting target %d location from surface %d to (%g,%g,%g)",
+                    CCTK_VINFO("Setting tracker %d location from surface %d to (%g,%g,%g)",
                                 itarget, which_surface_to_store_info[itarget], 
                                 target_loc_x[itarget], target_loc_y[itarget], target_loc_z[itarget]);
                 }

--- a/TargetTracker/src/TargetTracker.c
+++ b/TargetTracker/src/TargetTracker.c
@@ -73,7 +73,7 @@ void TargetChangeOneDim (CCTK_ARGUMENTS, struct TargetInfoBundleOneDim bundle) {
     if (tgt_id != *ptr_current_id) { // Target has changed
     
         // Check if target is fixed
-        if (!CCTK_Equals(tgt_name, "fixed")) {
+        if (!CCTK_Equals(tgt_name, "")) {
             
             // Check if new target exists
             if (tgt_id < 0) { // No such variable

--- a/TargetTracker/src/TargetTracker.h
+++ b/TargetTracker/src/TargetTracker.h
@@ -7,6 +7,16 @@
  * Contains helper functions for the TargetTracker thorn.
  */
 
+/////////////////////////////////////////////////////////////////////////////////
+// Helper struc to pass arguments to functions
+//////////////////////////////////////////////////////////////////////////////////
+struct TargetInfoBundleOneDim {
+    CCTK_INT itarget;
+    CCTK_INT* ptr_current_id;
+    const char* tgt_name;
+    const char* dim_name;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Helper function for factorization and consistency.
 // Gives the condition for a target to be active based on the current parameters

--- a/TargetTracker/src/TargetTracker.h
+++ b/TargetTracker/src/TargetTracker.h
@@ -7,9 +7,9 @@
  * Contains helper functions for the TargetTracker thorn.
  */
 
-/////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 // Helper struc to pass arguments to functions
-//////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 struct TargetInfoBundleOneDim {
     CCTK_INT itarget;
     CCTK_INT* ptr_current_id;
@@ -17,33 +17,11 @@ struct TargetInfoBundleOneDim {
     const char* dim_name;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-// Helper function for factorization and consistency.
-// Gives the condition for a target to be active based on the current parameters
-// and updates the is_active status of the target accordingly.
-////////////////////////////////////////////////////////////////////////////////
-
-inline void TargetActivationCondition(CCTK_ARGUMENTS, CCTK_INT itarget) {
-    DECLARE_CCTK_ARGUMENTS;
-    DECLARE_CCTK_PARAMETERS;
-
-    // Update value of internal is_tracked flag based on track parameter (which is STEERABLE=ALWAYS)
-    is_tracked[itarget] = track[itarget];
-
-    is_active[itarget] = ( 
-        is_tracked[itarget]
-        // &&  track_every[itarget] > 0     // Should be satisfied by construction
-        &&  (cctk_time >= start_tracking_after_time[itarget])
-        &&  (cctk_time <= stop_tracking_after_time[itarget])
-    );
-    return;
-}
-
 /////////////////////////////////////////////////////////////////////////////////////////
 // Helper function to print an error message and trigger termination after the time step.
 // Deactivates the concerned target.
 /////////////////////////////////////////////////////////////////////////////////////////
-inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget) {
+static inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget) {
     DECLARE_CCTK_ARGUMENTS;
 
     CCTK_VWARN(1, "%s", message);
@@ -51,5 +29,62 @@ inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarge
     CCTK_TerminateNext(cctkGH);
 
     is_active[itarget] = 0;
+    return;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function to update is_loc_from_surface flag.
+// We also check validity of the surface index.
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void UpdateIsLocFromSurface(CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    // Update value of internal is_loc_from_surface flag based on loc_from_surface_mode parameter (which is STEERABLE=ALWAYS)
+    is_loc_from_surface[itarget] = loc_from_surface_mode[itarget];
+
+    if (is_loc_from_surface[itarget]) {
+        // Not sure the second can happen in here because the relevant parameters
+        // are not always steerable, so they pass through ParamCheck.
+        // The first one can happen when steering loc_to_surface_mode from no to yes.
+        if (which_surface_to_store_info[itarget] == -1 || which_surface_to_store_info[itarget] >= nsurfaces) {
+            char error_message [1000];
+            sprintf(error_message,  "For target %d, 'loc_from_surface_mode' is yes "
+                                    "but 'which_surface_to_store_info = %d' is invalid.",
+                                    itarget, which_surface_to_store_info[itarget]);
+        
+            TerminateHelper(CCTK_PASS_CTOC, error_message, itarget);
+
+        }
+    }
+    return;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function for factorization and consistency.
+// Gives the condition for a target to be active based on the current parameters
+// and updates the is_active status of the target accordingly.
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void TargetActivationCondition(CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    // Update value of internal is_tracked flag based on track parameter (which is STEERABLE=ALWAYS)
+    is_tracked[itarget] = track[itarget];
+
+    // Update value of is_loc_from_surface flag based on loc_from_surface_mode parameter (which is STEERABLE=ALWAYS)
+    // WARNING: We consider that the target is inactive in that mode, but the tracker still has to follow the surface!
+    UpdateIsLocFromSurface(CCTK_PASS_CTOC, itarget);
+
+    is_active[itarget] = ( 
+        is_tracked[itarget]
+        && !loc_from_surface_mode[itarget]
+        // &&  track_every[itarget] > 0     // Should be satisfied by construction
+        &&  (cctk_time >= start_tracking_after_time[itarget])
+        &&  (cctk_time <= stop_tracking_after_time[itarget])
+    );
     return;
 }

--- a/TargetTracker/src/TargetTracker.h
+++ b/TargetTracker/src/TargetTracker.h
@@ -48,6 +48,7 @@ static inline void UpdateIsLocFromSurface(CCTK_ARGUMENTS, CCTK_INT itarget) {
         // Not sure the second can happen in here because the relevant parameters
         // are not always steerable, so they pass through ParamCheck.
         // The first one can happen when steering loc_to_surface_mode from no to yes.
+        // NOTE: This will be issued and terminate even if the target is not tracked nor active
         if (which_surface_to_store_info[itarget] == -1 || which_surface_to_store_info[itarget] >= nsurfaces) {
             char error_message [1000];
             sprintf(error_message,  "For target %d, 'loc_from_surface_mode' is yes "

--- a/TargetTracker/src/TargetTracker.h
+++ b/TargetTracker/src/TargetTracker.h
@@ -27,8 +27,11 @@ inline void TargetActivationCondition(CCTK_ARGUMENTS, CCTK_INT itarget) {
     DECLARE_CCTK_ARGUMENTS;
     DECLARE_CCTK_PARAMETERS;
 
+    // Update value of internal is_tracked flag based on track parameter (which is STEERABLE=ALWAYS)
+    is_tracked[itarget] = track[itarget];
+
     is_active[itarget] = ( 
-        track[itarget]
+        is_tracked[itarget]
         // &&  track_every[itarget] > 0     // Should be satisfied by construction
         &&  (cctk_time >= start_tracking_after_time[itarget])
         &&  (cctk_time <= stop_tracking_after_time[itarget])

--- a/TargetTracker/src/TargetTracker.h
+++ b/TargetTracker/src/TargetTracker.h
@@ -1,0 +1,42 @@
+#include <cctk.h>
+#include <cctk_Arguments.h>
+#include <cctk_Parameters.h>
+#include <cctk_Functions.h>
+
+/*
+ * Contains helper functions for the TargetTracker thorn.
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+// Helper function for factorization and consistency.
+// Gives the condition for a target to be active based on the current parameters
+// and updates the is_active status of the target accordingly.
+////////////////////////////////////////////////////////////////////////////////
+
+inline void TargetActivationCondition(CCTK_ARGUMENTS, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+    DECLARE_CCTK_PARAMETERS;
+
+    is_active[itarget] = ( 
+        track[itarget]
+        // &&  track_every[itarget] > 0     // Should be satisfied by construction
+        &&  (cctk_time >= start_tracking_after_time[itarget])
+        &&  (cctk_time <= stop_tracking_after_time[itarget])
+    );
+    return;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// Helper function to print an error message and trigger termination after the time step.
+// Deactivates the concerned target.
+/////////////////////////////////////////////////////////////////////////////////////////
+inline void TerminateHelper(CCTK_ARGUMENTS, const char* message, CCTK_INT itarget) {
+    DECLARE_CCTK_ARGUMENTS;
+
+    CCTK_VWARN(1, "%s", message);
+    CCTK_VWARN(1, "Deactivating target %d and triggering termination at iteration %d (simulation time %g).", itarget, cctk_iteration, cctk_time);
+    CCTK_TerminateNext(cctkGH);
+
+    is_active[itarget] = 0;
+    return;
+}

--- a/TargetTracker/src/make.code.defn
+++ b/TargetTracker/src/make.code.defn
@@ -1,7 +1,9 @@
 # Main make.code.defn file for thorn TargetTracker
 
 # Source files in this directory
-SRCS = TargetTracker.c
+SRCS =  TargetTracker.c  \
+        Initialization.c \
+        ParamCheck.c
 
 # Subdirectories containing source files
 SUBDIRS =

--- a/TargetTracker/src/make.code.defn
+++ b/TargetTracker/src/make.code.defn
@@ -1,0 +1,7 @@
+# Main make.code.defn file for thorn TargetTracker
+
+# Source files in this directory
+SRCS = TargetTracker.c
+
+# Subdirectories containing source files
+SUBDIRS =

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -67,7 +67,7 @@ schedule UAv_Initialization at BASEGRID after MultiPatch_SpatialCoordinates
 # schedule GROUP UAv_Analysis_Group in MoL_PseudoEvolution after MoL_PostStep
 ###############################################################################
 
-schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_masks
+schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_masks before TargetTracker_SetSurfaces
 {
 } "Compute several diagnostic quantities"
 


### PR DESCRIPTION
## Purpose

This PR introduces a new tracker thorn.
The goal is to be able to track any scalar quantity (provided by another thorn) in a modular way.
It gets inspiration from thorns `AHFinderDirect` and `NSTracker`, but tries to stay agnostic regarding physics (and reflect it in the name of the thorn).

## Usage

The parameter `track` is the most important.
It is always steerable and controls whether the corresponding tracker will do anything at all.

An empty target, as well as a non-tracked or otherwise inactive tracker, stays fixed at its last position.
An initial position for fixed targets can be given by `initial_x/y/z`.

The targets to follow are given by `target_x/y/z`, and are also always steerable.
They can be given or omitted independently in each dimension, the default empty string meaning that the target is fixed.
The positions of the targets are stored in the `target_loc` grid scalar (similar to `pt_loc` without `pt_loc_t`).

By default, no `SphericalSurface` is associated to a tracker, but the main goal is to affect one.
In that case, while the tracker is active, every `track_every` iterations, it will update the centroid of that surface to the value of `target_loc`.

**Important Note: the thorns that provide the grid scalars should be scheduled before `TargetTracker::TargetTracker_SetSurfaces`! Else, there may be an offset by one processed iteration.**

## Other features

- `start_tracking_after_time` and `stop_tracking_after_time` should be self-explanatory. 
- `force_params_at_recovery` (defaults to `no`): Parameters that are always steerable have a fundamental ambiguity at recovery.
If the parameter in the new parameter file does not coincide with the checkpointed one, is it because maybe the parameter file hasn't changed, but the parameter was steered in the run? Or is it an actual change in the parameter file that should be considered?\
Because `track` and `target_x/y/z` are built to possibly be steered, we decide to trust the checkpoint by default.
This parameter offers the possibility to force the parameters from the new parameter file.
- `loc_from_surface_mode` (defaults to `no`): Activates a mode where instead of copying a value from `target_loc` to the surface's centroid ('tracker to surface' mode), the reverse is done ('surface to tracker' mode).
In that case, `target_loc` "follows" the surface, presumably moved by another thorn (for instance, if a horizon has formed and `AHFinderDirect` now sets the surface).

## Notes

- The parameters that should be steered at runtime to activate/deactivate trackers are `track`, `target_x/y/z` and `loc_from_surface_mode`.
The other parameters are steerable at recovery only.
Note that at recovery, commenting out a parameter will not steer its value to the default (Cactus behavior).

- Mid-run errors caused by wrongly steered parameters will result in a merciful termination at the end of the time step, rather than plain abortion.

## Possible TODOs

- Add proper documentation, README...
- Add tests, parfiles, ...
- Add other options such as
- [ ] track opposite of a grid scalar (cf `NSTracker`)
- [ ] self-contained targets like center of mass etc.
- [ ] target a whole group at once instead of individual scalars
- [ ] change the surface radius too
- [ ] ...

