### PR TITLE
UAv_IDBHScalarHair: minimum radius eps_R & scalar field parity parameter

### DIFF
--- a/UAv_IDBHScalarHair/param.ccl
+++ b/UAv_IDBHScalarHair/param.ccl
@@ -55,10 +55,8 @@ INT mm "azimuthal number of the solution. mm=0 for solutions with spherical symm
 } 0
 
 # Symmetry of the scalar field, with respect to the equatorial plane (initial data is provided for 0 <= theta <= pi/2).
-# We write A = phi exp{i(m varphi - w t)}.
-# phi even (default)
-# phi odd
-BOOLEAN phi_z_sym_is_odd "Parity of scalar field with respect to equatorial plane symmetry. So far, used only in HairyBH."
+# With Phi = phi exp{i(m varphi - w t)}, phi z-even is the default.
+BOOLEAN phi_z_sym_is_odd "Parity of the scalar field with respect to equatorial (z-)plane symmetry."
 {
 } "no"
 

--- a/UAv_IDBHScalarHair/param.ccl
+++ b/UAv_IDBHScalarHair/param.ccl
@@ -54,6 +54,14 @@ INT mm "azimuthal number of the solution. mm=0 for solutions with spherical symm
   0:3 :: "0, 1, 2 or 3"
 } 0
 
+# Symmetry of the scalar field, with respect to the equatorial plane (initial data is provided for 0 <= theta <= pi/2).
+# We write A = phi exp{i(m varphi - w t)}.
+# phi even (default)
+# phi odd
+BOOLEAN phi_z_sym_is_odd "Parity of scalar field with respect to equatorial plane symmetry. So far, used only in HairyBH."
+{
+} "no"
+
 INT maxNF "maximum number of lines allowed in the input file"
 {
  100:* :: "any large enough integer"

--- a/UAv_IDBHScalarHair/param.ccl
+++ b/UAv_IDBHScalarHair/param.ccl
@@ -96,6 +96,11 @@ REAL z0 "z coordinate of central point"
   *:* :: "any real number"
 } 0.0
 
+CCTK_REAL eps_R "floor value for RR"
+{
+  0:*  :: "any small positive value"
+} 1.0d-12
+
 
 REAL Apert_conf_fac "amplitude for conformal factor perturbation"
 {

--- a/UAv_IDBHScalarHair/param.ccl
+++ b/UAv_IDBHScalarHair/param.ccl
@@ -96,7 +96,7 @@ REAL z0 "z coordinate of central point"
   *:* :: "any real number"
 } 0.0
 
-CCTK_REAL eps_R "floor value for RR"
+CCTK_REAL eps_R "floor value for RR (not used for ScalarBS)."
 {
   0:*  :: "any small positive value"
 } 1.0d-12

--- a/UAv_IDBHScalarHair/src/BHScalarHair.c
+++ b/UAv_IDBHScalarHair/src/BHScalarHair.c
@@ -340,8 +340,10 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
 
   // Second loop on z<0 half-space (completion by symmetry)
 
-  // Even parity: F1, F2, F0, phi0, Wbar and their r derivatives
+  // Even parity: F1, F2, F0, Wbar and their r derivatives
   // Odd parity:  theta derivatives of even functions
+  // phi: depends on parameter phi_z_sym_is_odd (= no by default)
+  const CCTK_INT phi0_z_sign = phi_z_sym_is_odd ? -1 : +1;
 
   for (int jj = 1; jj < Ntheta; jj++) { // don't repeat theta == pi/2
     for (int i = 0; i < NX; i++) {
@@ -357,14 +359,16 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
       F1_extd[ind]       = F1_extd[indsym];
       F2_extd[ind]       = F2_extd[indsym];
       F0_extd[ind]       = F0_extd[indsym];
-      phi0_extd[ind]     = phi0_extd[indsym];
-
+      
       Wbar_extd[ind]     = Wbar_extd[indsym];
       dWbar_dr_extd[ind] = dWbar_dr_extd[indsym];
-
+      
       // Odd
       dWbar_dth_extd[ind]   = - dWbar_dth_extd[indsym];
       d2Wbar_drth_extd[ind] = - d2Wbar_drth_extd[indsym];
+      
+      // Scalar field
+      phi0_extd[ind] = phi0_z_sign * phi0_extd[indsym];
 
       } // for i
   } // for jj

--- a/UAv_IDBHScalarHair/src/BHScalarHair.c
+++ b/UAv_IDBHScalarHair/src/BHScalarHair.c
@@ -389,25 +389,31 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
         const CCTK_REAL z1  = z[ind] - z0;
 
         const CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        
+        // RR=0 is mapped to infinity, which is X=1
+        // In theory it's the whole sphere, but practically z=0 so theta=0
+        if(RR2 < pow(eps_R, 2)) {
+          X_g[ind]     = 1.;
+          theta_g[ind] = 0.;
+        
+        } else {
 
-        CCTK_REAL RR  = sqrt(RR2);
-        /* note that there are divisions by RR in the following expressions.
-           divisions by zero should be avoided by choosing a non-zero value for
-           z0 (for instance) */
+          const CCTK_REAL RR  = sqrt(RR2);
 
-        // from (quasi-)isotropic coordinate R to the metric coordinate r
-        const CCTK_REAL rr = RR * (1. + 0.25 * rH / RR) * (1. + 0.25 * rH / RR);
+          // from (quasi-)isotropic coordinate R to the metric coordinate r
+          const CCTK_REAL rr = RR * (1. + 0.25 * rH / RR) * (1. + 0.25 * rH / RR);
 
-        // from the metric coordinate r to the x coordinate
-        const CCTK_REAL rx = sqrt(rr*rr - rH*rH);
+          // from the metric coordinate r to the x coordinate
+          const CCTK_REAL rx = sqrt(rr*rr - rH*rH);
 
-        // and finally to the X radial coordinate (used in input files)
-        const CCTK_REAL lX = rx / (C0 + rx);
+          // and finally to the X radial coordinate (used in input files)
+          const CCTK_REAL lX = rx / (C0 + rx);
 
-        const CCTK_REAL ltheta = acos( z1/RR );
+          const CCTK_REAL ltheta = acos( z1/RR );
 
-        X_g[ind]     = lX;
-        theta_g[ind] = ltheta;
+          X_g[ind]     = lX;
+          theta_g[ind] = ltheta;
+        }
       }
     }
   }
@@ -552,10 +558,11 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
         const CCTK_REAL y1  = y[ind] - y0;
         const CCTK_REAL z1  = z[ind] - z0;
 
-        const CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
-        /* note that there are divisions by RR in the following expressions.
-           divisions by zero should be avoided by choosing a non-zero value for
-           z0 (for instance) */
+        CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        /* To avoid divisions by RR=0, we use a small value instead.
+           Alternatively, use a non-zero z0 (for instance) */
+        if(RR2 < pow(eps_R, 2)) 
+          RR2 = pow(eps_R, 2);
 
         const CCTK_REAL RR  = sqrt(RR2);
 
@@ -567,6 +574,8 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
         /*
         const CCTK_REAL rho2 = x1*x1 + y1*y1;
         const CCTK_REAL rho  = sqrt(rho2);
+
+        // TODO: If using rho, should we use eps_R there too?
         */
 
         const CCTK_REAL costh  = z1/RR;
@@ -609,8 +618,6 @@ void UAv_IDBHScalarHair(CCTK_ARGUMENTS)
         const CCTK_REAL cosmph = cos(mm*ph);
         const CCTK_REAL sinmph = sin(mm*ph);
 
-        /* note the division by RR in the following. divisions by zero should be
-           avoided by choosing a non-zero value for z0 (for instance) */
         const CCTK_REAL aux  = 1. + 0.25 * rH/RR;
         const CCTK_REAL aux2 = aux  * aux;
         const CCTK_REAL aux4 = aux2 * aux2;

--- a/UAv_IDBHScalarHair/src/Kerr_test.c
+++ b/UAv_IDBHScalarHair/src/Kerr_test.c
@@ -52,9 +52,14 @@ void UAv_Kerr_test(CCTK_ARGUMENTS)
         const CCTK_REAL z1  = z[ind] - z0;
 
         const CCTK_REAL rho2 = x1*x1 + y1*y1;
+        // TODO: should we use eps_R there too?
         // const CCTK_REAL rho  = sqrt(rho2);
 
-        const CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        /* To avoid divisions by RR=0, we use a small value instead.
+           Alternatvely, use a non-zero z0 (for instance) */
+        CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        if(RR2 < pow(eps_R, 2)) 
+          RR2 = pow(eps_R, 2);
         const CCTK_REAL RR  = sqrt(RR2);
 
         const CCTK_REAL r  = RR * (1 + 0.25 * rH/RR) * (1 + 0.25 * rH/RR);
@@ -64,9 +69,6 @@ void UAv_Kerr_test(CCTK_ARGUMENTS)
         const CCTK_REAL sinth2 = 1. - costh2;
         const CCTK_REAL sinth  = sqrt(sinth2);
 
-        /* note that there are divisions by RR in the following expressions.
-           divisions by zero should be avoided by choosing a non-zero value for
-           z0 (for instance) */
 
         F1[ind] = (1.0/2.0)*log(pow(-1 + 16*ct/(RR*pow(4 + rH/RR, 2)), 2) + 256*ct*(ct - rH)*pow(z1, 2)/(pow(RR, 4)*pow(4 + rH/RR, 4)));
 
@@ -110,18 +112,33 @@ void UAv_Kerr_test(CCTK_ARGUMENTS)
         const CCTK_REAL y1  = y[ind] - y0;
         const CCTK_REAL z1  = z[ind] - z0;
 
-        const CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
+        if(RR2 < pow(eps_R, 2)) 
+          RR2 = pow(eps_R, 2);
         const CCTK_REAL RR  = sqrt(RR2);
 
         /*
         const CCTK_REAL rho2 = x1*x1 + y1*y1;
         const CCTK_REAL rho  = sqrt(rho2);
+
+        // TODO: If using rho, should we use eps_R there too?
         */
 
         const CCTK_REAL costh  = z1/RR;
         const CCTK_REAL costh2 = costh*costh;
-        const CCTK_REAL sinth2 = 1. - costh2;
-        const CCTK_REAL sinth  = sqrt(sinth2);
+        /*
+          For some grid points actually on the axis, it occurred that costh = 1-1e-16, resulting in sinth ~ 1.5e-8 instead of 0.
+          Thus we force it in that case. 
+          Even if there is a legit grid point such that theta ~ a few 1e-8, it should mean RR >> rho and the axis treatment should be fine.
+        */
+        CCTK_REAL sinth, sinth2;
+        if (1-costh2 < 1e-15) {
+          sinth2 = 0.;
+          sinth  = 0.;
+        } else {
+          sinth2 = 1. - costh2;
+          sinth  = sqrt(sinth2);
+        }
 
         /*
         const CCTK_REAL R_x = x1/RR;   // dR/dx
@@ -147,8 +164,6 @@ void UAv_Kerr_test(CCTK_ARGUMENTS)
         const CCTK_REAL cosmph = cos(mm*ph);
         const CCTK_REAL sinmph = sin(mm*ph);
 
-        /* note the division by RR in the following. divisions by zero should be
-           avoided by choosing a non-zero value for z0 (for instance) */
         const CCTK_REAL aux  = 1. + 0.25 * rH/RR;
         const CCTK_REAL aux2 = aux  * aux;
         const CCTK_REAL aux4 = aux2 * aux2;

--- a/UAv_IDBHScalarHair/src/Kerr_test.c
+++ b/UAv_IDBHScalarHair/src/Kerr_test.c
@@ -56,7 +56,7 @@ void UAv_Kerr_test(CCTK_ARGUMENTS)
         // const CCTK_REAL rho  = sqrt(rho2);
 
         /* To avoid divisions by RR=0, we use a small value instead.
-           Alternatvely, use a non-zero z0 (for instance) */
+           Alternatively, use a non-zero z0 (for instance) */
         CCTK_REAL RR2 = x1*x1 + y1*y1 + z1*z1;
         if(RR2 < pow(eps_R, 2)) 
           RR2 = pow(eps_R, 2);

--- a/UAv_IDBHScalarHair/src/ParamCheck.c
+++ b/UAv_IDBHScalarHair/src/ParamCheck.c
@@ -31,6 +31,9 @@ void UAv_IDBHScalarHair_ParamCheck(CCTK_ARGUMENTS){
       CCTK_PARAMWARN("Using 'initial_data = HairyBH' with a non-zero 'omega_BS' is not allowed. "
                    "Unset 'omega_BS' and check that you set 'OmegaH' and 'rH' properly.");
     }
+
+    // TODO?: Treatment of RR==0
+    // Idea would be to have `if (eps_R==0 && x0==0 && y0==0 && z0==0)`, but double comparison is always tricky.
   }
 
   // Scalar BS simulation: use omega_BS, not OmegaH nor rH.

--- a/UAv_IDBHScalarHair/src/ScalarBS.c
+++ b/UAv_IDBHScalarHair/src/ScalarBS.c
@@ -324,8 +324,10 @@ void UAv_IDScalarBS(CCTK_ARGUMENTS)
 
   // Second loop on z<0 half-space (completion by symmetry)
 
-  // Even parity: F1, F2, F0, phi0, W and their r derivatives
+  // Even parity: F1, F2, F0, W and their r derivatives
   // Odd parity:  theta derivatives of even functions
+  // phi: depends on parameter phi_z_sym_is_odd (= no by default)
+  const CCTK_INT phi0_z_sign = phi_z_sym_is_odd ? -1 : +1;
 
   for (int jj = 1; jj < Ntheta; jj++) { // don't repeat theta == pi/2
     for (int i = 0; i < NX; i++) {
@@ -341,13 +343,15 @@ void UAv_IDScalarBS(CCTK_ARGUMENTS)
       F1_extd[ind]       = F1_extd[indsym];
       F2_extd[ind]       = F2_extd[indsym];
       F0_extd[ind]       = F0_extd[indsym];
-      phi0_extd[ind]     = phi0_extd[indsym];
 
       W_extd[ind]        = W_extd[indsym];
       dW_dr_extd[ind]    = dW_dr_extd[indsym];
 
       // Odd
       dW_dth_extd[ind]   = - dW_dth_extd[indsym];
+
+      // Scalar field
+      phi0_extd[ind]     = phi0_z_sign * phi0_extd[indsym];
 
       } // for i
   } // for jj


### PR DESCRIPTION
## Feature 1: minimum radius

In a fashion similar to other thorns, have a minimal radius allowed when putting the initial data on the evolution grid.
More precisely, if the evolution-grid coordinate radius $R < \epsilon_R$, it is set to $\epsilon_R$ instead.

### Notes
- $\epsilon_R$ appears as a new parameter `eps_R` (default `1.0d-12`)
- This complements (non-exclusively) the previous strategy to use a non-all-vanishing $(x_0, y_0, z_0)$ puncture initial coordinate.
- There is no consistency check that this triplet and $\epsilon_R$ are non-simultaneously vanishing because of double comparison (_should one be added?_)
- It is used for `initial_data == HairyBH` and `Kerr_test`, not for `ScalarBS`. In the latter, the axis is already dealt with specifically.


## Feature 2: $z$-symmetry of the scalar field

The current infrastructure reads initial data between $0$ and $\pi/2$, and computes points with $z<0$ by _even_ symmetry.
A new parameter `phi_z_sym_is_odd` (default `no`) is added to allow for odd symmetry of the scalar field with respect to the equatorial plane.

### Notes

- Added for both `HairyBH` and `ScalarBS`, but only tested for one `HairyBH` solution. (This was also tested, in another branch, on the more involved Proca field.)