### PR TITLE
Analysis: schedule and interface improvements

### DIFF
--- a/UAv_Analysis/interface.ccl
+++ b/UAv_Analysis/interface.ccl
@@ -23,11 +23,11 @@ CCTK_INT is_multipatch type=scalar timelevels=1 tags='checkpoint="no"' "Flag to 
 
 CCTK_INT use_volume_form type=scalar timelevels=1 tags='checkpoint="no"' "Flag to know if we can use the volume form from the multipatch grid."
 
-CCTK_REAL total_energy type=scalar timelevels=1 tags='checkpoint="no"' "Komar mass (volume integral). See Gourgoulhon's 3+1 Formalism, sections 8.6.1 and 8.6.2 (Eq. 8.63 and 8.70)."
+CCTK_REAL total_energy type=scalar timelevels=1 tags='checkpoint="yes"' "Komar mass (volume integral). See Gourgoulhon's 3+1 Formalism, sections 8.6.1 and 8.6.2 (Eq. 8.63 and 8.70)."
 
 CCTK_REAL dE_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortypealias="Scalar" checkpoint="no"' "energy density gridfunction for volume integration"
 
-CCTK_REAL total_angular_momentum type=scalar timelevels=1 tags='checkpoint="no"'
+CCTK_REAL total_angular_momentum type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   total_angular_momentum_x
   total_angular_momentum_y
@@ -41,7 +41,7 @@ CCTK_REAL dJ_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortype
   dJz_gf_volume
 } "angular momentum density J_i gridfunctions for volume integration"
 
-CCTK_REAL center_of_mass type=scalar timelevels=1 tags='checkpoint="no"'
+CCTK_REAL center_of_mass type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   center_of_mass_x
   center_of_mass_y
@@ -57,7 +57,7 @@ CCTK_REAL dCoM_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensorty
   dCoMz_gf_volume
 } "density_rho*x^i gridfunctions for volume integration. Note that we use x, and not x-x0, so that the density GF can be safely used in other thorns."
 
-CCTK_REAL linear_momentum type=scalar timelevels=1 tags='checkpoint="no"'
+CCTK_REAL linear_momentum type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   linear_momentum_x
   linear_momentum_y
@@ -71,7 +71,7 @@ CCTK_REAL dp_gf_volume type=gf timelevels=3 tags='Prolongation="none" tensortype
   dpz_gf_volume
 } "momentum density gridfunctions for volume integration"
 
-CCTK_REAL quadrupole type=scalar timelevels=1 tags='checkpoint="no"'
+CCTK_REAL quadrupole type=scalar timelevels=1 tags='checkpoint="yes"'
 {
   Ixx, Ixy, Ixz
   Iyy, Iyz
@@ -97,7 +97,7 @@ CCTK_REAL density_p type=gf timelevels=3 tags='tensortypealias="D" tensorweight=
   density_pz
 } "Eulerian momentum density"
 
-CCTK_REAL origin_coordinates type=scalar tags='checkpoint="no"'
+CCTK_REAL origin_coordinates type=scalar tags='checkpoint="yes"'
 {
   x0, y0, z0
 } "Coordinates of the origin used in the analysis"

--- a/UAv_Analysis/param.ccl
+++ b/UAv_Analysis/param.ccl
@@ -11,6 +11,14 @@ INT do_analysis_every "Perform the analysis (compute the energy, densities...) e
     *:*  :: "0 or a negative value means never compute them"
 } 1
 
+BOOLEAN run_at_CCTK_ANALYSIS "run at CCTK_ANALYSIS (default). You may want to set it to 'no' if you already run at another schedule bin." STEERABLE=RECOVER
+{
+} "yes"
+
+BOOLEAN run_at_CCTK_POSTSTEP "run at CCTK_POSTSTEP (not by default)." STEERABLE=RECOVER
+{
+} "no"
+
 BOOLEAN compute_density_rho "Compute the grid function density_rho" STEERABLE=ALWAYS
 {
 } "no"

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -88,9 +88,9 @@ schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_mask
 # This can happen if the origin used in the analysis is tracking the center of mass,
 # or if the user explicitly forces it with the parameter `force_early_CoM` (possibly
 # to use it in other thorns).
-# The functions will return if they are not needed (dictated by variable `early_CoM`).
+# The group is scheduled depending on the value of `UAv_Analysis::early_CoM`.
 
-schedule GROUP UAv_Analysis_early_CoM_Group in UAv_Analysis_Group before UAv_Track_origin
+schedule GROUP UAv_Analysis_early_CoM_Group in UAv_Analysis_Group before UAv_Track_origin if UAv_Analysis::early_CoM
 {
 } "Compute the center of mass and density earlier than normally, in case it is used for origin tracking by this thorn."
 

--- a/UAv_Analysis/schedule.ccl
+++ b/UAv_Analysis/schedule.ccl
@@ -66,22 +66,42 @@ schedule UAv_Initialization at BASEGRID after MultiPatch_SpatialCoordinates
 
 ###############################################################################
 # WARNING/NOTE:
-# It seems to be working fine with AHFinderDirect, even when the latter runs
-# at ANALYSIS, but if in doubt, maybe run AHFinderDirect at POSTSTEP (which
+#
+# SPECIAL CARE AND REVISION should be taken about schedule bins, timelevels, 
+# and the code itself, if derivatives/stencils are computed in the analysis.
+# As operations are currently pointwise, it should be OK to compute every so
+# often (in ANALYSIS or POSTSTEP), but iterations in between coarse grid time 
+# steps will be ill-defined and can contain erroneous values or nans.
+#  
+#
+# The thorn seems to be working fine with AHFinderDirect, even when the latter
+# runs at ANALYSIS, but if in doubt, maybe run AHFinderDirect at POSTSTEP (this
 # is the current default), this should make sure the excision mask is there.
 #
 # For a discussion about the schedule options, such as "local" versus "global
 # loop-local", as well as the schedule bins, see the users list archives
 # https://lists.einsteintoolkit.org/pipermail/users/2024-September/009456.html
 # and corresponding thread (several back and forth replies).
+# See also
+# https://lists.einsteintoolkit.org/pipermail/users/2026-June/009955.html
 # 
 # A possible schedule in EVOL would be
 # schedule GROUP UAv_Analysis_Group in MoL_PseudoEvolution after MoL_PostStep
 ###############################################################################
 
-schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_masks before TargetTracker_SetSurfaces
+if (run_at_CCTK_POSTSTEP)
 {
-} "Compute several diagnostic quantities"
+  schedule GROUP UAv_Analysis_Group at CCTK_POSTSTEP after AHFinderDirect_maybe_do_masks before TargetTracker_SetSurfaces
+  {
+  } "Compute several diagnostic quantities"
+}
+
+if (run_at_CCTK_ANALYSIS)
+{
+  schedule GROUP UAv_Analysis_Group at ANALYSIS after AHFinderDirect_maybe_do_masks before TargetTracker_SetSurfaces
+  {
+  } "Compute several diagnostic quantities"
+}
 
 ##### EARLY COM GROUP #####
 # We may need to compute the center of mass earlier than the other grid functions.
@@ -104,7 +124,7 @@ schedule UAv_Analysis_early_CoM_gfs in UAv_Analysis_early_CoM_Group
 schedule UAv_Analysis_Boundaries_early_CoM after UAv_Analysis_early_CoM_gfs in UAv_Analysis_early_CoM_Group
 {
   LANG: Fortran
-  OPTIONS: LEVEL
+  OPTIONS: global-early loop-level
   SYNC: density_rho
 } "Enforce symmetry BCs in Analysis"
 
@@ -162,5 +182,5 @@ schedule GROUP ApplyBCs as UAv_Analysis_ApplyBCs after UAv_Analysis_Boundaries i
 schedule UAv_Analysis_IntegrateVol after UAv_Analysis_ApplyBCs in UAv_Analysis_Group
 {
   LANG: C
-  OPTIONS: global
+  OPTIONS: global-late
 } "Compute volume integrals"

--- a/UAv_Analysis/src/ParamCheck.c
+++ b/UAv_Analysis/src/ParamCheck.c
@@ -11,6 +11,23 @@ void UAv_Analysis_ParamCheck(CCTK_ARGUMENTS){
   DECLARE_CCTK_PARAMETERS;
 
   // -------------------------------
+  // SCHEDULE
+  // -------------------------------
+
+  // Make sure it is run at least once
+  if (!run_at_CCTK_ANALYSIS && !run_at_CCTK_POSTSTEP) {
+    CCTK_VPARAMWARN("UAv_Analysis thorn is not scheduled to run at CCTK_ANALYSIS or CCTK_POSTSTEP. " 
+                    "Please set at least one of the parameters run_at_CCTK_ANALYSIS or run_at_CCTK_POSTSTEP to yes.");
+  }
+
+  // Simple warning if both are set to yes, but we don't forbid it
+  if (run_at_CCTK_ANALYSIS && run_at_CCTK_POSTSTEP) {
+    CCTK_WARN(CCTK_WARN_COMPLAIN, "UAv_Analysis thorn is scheduled to run at both CCTK_ANALYSIS and CCTK_POSTSTEP. " 
+                    "This is not forbidden, but it may be redundant, wasteful or lead to unexpected behavior. "
+                    "Please check your parameters.");
+  }
+
+  // -------------------------------
   // MULTIPATCH
   // -------------------------------
   

--- a/UAv_Analysis/src/UAv_Analysis_gfs.F90
+++ b/UAv_Analysis/src/UAv_Analysis_gfs.F90
@@ -322,9 +322,7 @@ subroutine UAv_Analysis_early_CoM_gfs( CCTK_ARGUMENTS )
   ! Cartesian volume element used without multipatch
   CCTK_REAL dV_cart
 
-  if (early_CoM == 0) then
-    return
-  end if
+  ! The `if (early_CoM == 0)` statement is moved to the schedule directly.
   
   if (do_analysis_every .le. 0) then
     return

--- a/UAv_Analysis/src/UAv_Analysis_reductions.c
+++ b/UAv_Analysis/src/UAv_Analysis_reductions.c
@@ -160,9 +160,7 @@ void UAv_Analysis_early_CoM_reduce(CCTK_ARGUMENTS)
   DECLARE_CCTK_ARGUMENTS;
   DECLARE_CCTK_PARAMETERS;
 
-  if (*early_CoM == 0) {
-    return;
-  }
+  // The `if(*early_CoM)` statement is moved to the schedule directly.
 
   if (do_analysis_every <= 0) {
     return;

--- a/UAv_Analysis/src/UAv_Boundaries.F90
+++ b/UAv_Analysis/src/UAv_Boundaries.F90
@@ -57,9 +57,7 @@ subroutine UAv_Analysis_Boundaries_early_CoM( CCTK_ARGUMENTS )
   CCTK_INT, parameter :: one = 1
   CCTK_INT, parameter :: bndsize = 3
 
-  if (early_CoM == 0) then
-     return
-  end if
+  ! The `if (early_CoM == 0)` statement is moved to the schedule directly.
 
   if (do_analysis_every .le. 0) then
      return


### PR DESCRIPTION
## Improvement 1: checkpoint scalars

Useful after checkpoint recovery, if the simulation doesn't restart on an iteration that computes the scalars.
It is relevant for instance if something else (like a `Trigger`) relies on those.

## Improvement 2: moved the `if (early_CoM)` condition to schedule

The toolkit allows for conditional scheduling based on grid scalars.
We can then put one `if (early_CoM)` in the schedule block, instead of checks-returns in the functions.

**Note:** One change was missing in commit 02fb63ebd8624f6056003187d0fed55cbe9058a9 and was added in commit 9572823f44d30ba4879838102cb35f066c0f752a

> `schedule.ccl` , block `schedule UAv_Analysis_Boundaries_early_CoM`
>> `OPTIONS: global-early loop-level`

## Improvement 3: added the possibility to schedule the analysis at `POSTSTEP`

This may be more compliant with the Toolkit rationale for quantities that are used in other thorns (which shouldn't be the case for stuff at `ANALYSIS`).
This is controlled by parameters, the default being still at `ANALYSIS`.

**WARNING:** This may work as such because we only compute point-wise quantities.
Just like before at `ANALYSIS`, computing quantities in between coarse level time steps is dangerous, as the coarser grids will have potentially poisoned or ill-defined values (for the latter, in particular close to start/recovery).
In the current implementation, it seems that even computing at each iteration at `POSTSTEP` is not enough to have proper behavior at intermediate times.